### PR TITLE
Dummy constant for open source shim

### DIFF
--- a/shim/resources.py
+++ b/shim/resources.py
@@ -9,6 +9,9 @@ from .constant import Constant
 
 
 def get_string(constant: Constant) -> str:
+    if constant == Constant.BINARY_BUILD_MODE:
+        return "<build mode>"
+
     raise NotImplementedError(f"Unknown string constant `{constant}`")
 
 


### PR DESCRIPTION
This gets loaded when the shim is loaded.

Test plan:
```
[mariana-trench]$ PYTHONPATH=../redex/install/bin/ python3 -m shim.shim --help
```