### PR TITLE
[mariana trench] fix sample app build

### DIFF
--- a/documentation/sample-app/app/build.gradle
+++ b/documentation/sample-app/app/build.gradle
@@ -5,6 +5,10 @@ plugins {
 android {
     compileSdkVersion 30
 
+    lintOptions {
+        abortOnError false
+    }
+
     defaultConfig {
         applicationId "com.example.myapplication"
         minSdkVersion 24


### PR DESCRIPTION
This would fail with lint errors when running gradle.

Test Plan:
```
[sample-app]$ ANDROID_SDK_ROOT=/opt/android_sdk gradle build
```