### PR TITLE
Add a Github action to build and publish the pypi package

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,97 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish'
+        required: true
+
+jobs:
+  build-macos:
+    runs-on: macos-11
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: brew install meson
+
+      - name: Fetch Redex
+        run: git clone https://github.com/facebook/redex.git
+
+      - name: Build static binary
+        run: ./scripts/build_static_binary.py --jobs=$(sysctl -n hw.ncpu)
+
+      - name: Build pypi package
+        run: |
+          ./scripts/setup.py \
+            --version "${{ github.event.inputs.version }}" \
+            --binary mariana-trench-binary \
+            --pyredex redex/pyredex \
+            build
+
+      - name: Log the output directory
+        run: ls -lisah dist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: macos-wheels
+          path: dist/
+          if-no-files-found: error
+
+  build-ubuntu:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: sudo apt-get install meson
+
+      - name: Fetch Redex
+        run: git clone https://github.com/facebook/redex.git
+
+      - name: Build static binary
+        run: ./scripts/build_static_binary.py --jobs=$(nproc)
+
+      - name: Build pypi package
+        run: |
+          ./scripts/setup.py \
+            --version "${{ github.event.inputs.version }}" \
+            --binary mariana-trench-binary \
+            --pyredex redex/pyredex \
+            build
+
+      - name: Log the output directory
+        run: ls -lisah dist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ubuntu-wheels
+          path: dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    runs-on: ubuntu-20.04
+    needs: [build-macos, build-ubuntu]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Make a 'dist' folder
+        run: mkdir dist
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: macos-wheels
+          path: ./dist
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: ubuntu-wheels
+          path: ./dist
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Successful run - https://github.com/facebook/mariana-trench/actions/runs/1036466388 
PyPI now shows version 0.dev3 - https://pypi.org/project/mariana-trench/, confirmed that this runs on both mac and linux