### PR TITLE
[MT] Add `AnyParam` method constraint

### DIFF
--- a/documentation/website/documentation/models.md
+++ b/documentation/website/documentation/models.md
@@ -729,6 +729,7 @@ Each "rule" defines a "filter" (which uses "constraints" to specify methods for 
       - `parent` (a single string) or `parents` (a list of alternative strings) is exact matched to the  class of the method or `extends` (either a single string or a list of alternative strings) is exact matched to the base classes or interfaces of the method. `extends` allows an additional property `includes_self` which is a boolean to indicate if the constraint is applied to the class itself or not.
     - `parent`: Expects an extra property `inner` [Type] which contains a nested constraint to apply to the class holding the method;
     - `parameter`: Expects an extra properties `idx` and `inner` [Parameter] or [Type], matches when the idx-th parameter of the function or method matches the nested constraint inner;
+    - `any_parameter`: Expects an optional extra property `start_idx` and `inner` [Parameter] or [Type], matches when there is any parameters (starting at start_idx) of the function or method matches the nested constraint inner;
     - `return`: Expects an extra property `inner` [Type] which contains a nested constraint to apply to the return of the method;
     - `is_static | is_constructor | is_native | has_code`: Accepts an extra property `value` which is either `true` or `false`. By default, `value` is considered `true`;
     - `number_parameters`: Expects an extra property `inner` [Integer] which contains a nested constraint to apply to the number of parameters (counting the implicit `this` parameter);

--- a/source/JsonValidation.cpp
+++ b/source/JsonValidation.cpp
@@ -105,6 +105,21 @@ int JsonValidation::integer(
   return integer.asInt();
 }
 
+std::optional<int> JsonValidation::optional_integer(
+    const Json::Value& value,
+    const std::string& field) {
+  validate_object(
+      value, fmt::format("non-null object with integer field `{}`", field));
+  const auto& integer = value[field];
+  if (integer.isNull()) {
+    return std::nullopt;
+  }
+  if (!integer.isInt()) {
+    throw JsonValidationError(value, field, /* expected */ "integer");
+  }
+  return integer.asInt();
+}
+
 bool JsonValidation::boolean(const Json::Value& value) {
   if (value.isNull() || !value.isBool()) {
     throw JsonValidationError(

--- a/source/JsonValidation.h
+++ b/source/JsonValidation.h
@@ -42,6 +42,7 @@ class JsonValidation final {
 
   static int integer(const Json::Value& value);
   static int integer(const Json::Value& value, const std::string& field);
+  static std::optional<int> optional_integer(const Json::Value& value, const std::string& field);
 
   static bool boolean(const Json::Value& value);
   static bool boolean(const Json::Value& value, const std::string& field);

--- a/source/constraints/MethodConstraints.h
+++ b/source/constraints/MethodConstraints.h
@@ -214,6 +214,19 @@ class NthParameterConstraint final : public MethodConstraint {
   std::unique_ptr<ParameterConstraint> inner_constraint_;
 };
 
+class AnyParameterConstraint final : public MethodConstraint {
+ public:
+  AnyParameterConstraint(
+      std::optional<ParameterPosition> start_index,
+      std::unique_ptr<ParameterConstraint> inner_constraint);
+  bool satisfy(const Method* method) const override;
+  bool operator==(const MethodConstraint& other) const override;
+
+ private:
+  std::optional<ParameterPosition> start_index_;
+  std::unique_ptr<ParameterConstraint> inner_constraint_;
+};
+
 class SignaturePatternConstraint final : public MethodConstraint {
  public:
   explicit SignaturePatternConstraint(const std::string& regex_string);

--- a/source/model-generator/tests/MethodConstraintTest.cpp
+++ b/source/model-generator/tests/MethodConstraintTest.cpp
@@ -351,6 +351,42 @@ TEST_F(MethodConstraintTest, NthParameterConstraintSatisfy) {
   EXPECT_FALSE(constraint.satisfy(context.methods->create(methods[1])));
 }
 
+TEST_F(MethodConstraintTest, AnyParameterConstraintSatisfy) {
+  Scope scope;
+  auto context = test::make_empty_context();
+  auto methods = redex::create_methods(
+      scope,
+      "LClass;",
+      {
+          R"(
+            (method (public static) "LClass;.method_1:(Landroid/content/Intent;I)V"
+            (
+              (return-void)
+            )
+            ))",
+          R"(
+            (method (public) "LClass;.method_2:(ILandroid/content/Intent;)V"
+            (
+              (return-void)
+            )
+            ))",
+      });
+  auto constraint = AnyParameterConstraint(
+      std::nullopt /* start_idx */,
+      std::make_unique<TypeParameterConstraint>(
+          std::make_unique<TypePatternConstraint>("Landroid/content/Intent;")));
+
+  EXPECT_TRUE(constraint.satisfy(context.methods->create(methods[0])));
+  EXPECT_TRUE(constraint.satisfy(context.methods->create(methods[1])));
+
+  auto constraint2 = AnyParameterConstraint(
+      1 /* start_idx */,
+      std::make_unique<TypeParameterConstraint>(
+          std::make_unique<TypePatternConstraint>("Landroid/content/Intent;")));
+    EXPECT_FALSE(constraint2.satisfy(context.methods->create(methods[0])));
+    EXPECT_TRUE(constraint2.satisfy(context.methods->create(methods[1])));
+}
+
 TEST_F(MethodConstraintTest, SignaturePatternConstraintSatisfy) {
   Scope scope;
   auto context = test::make_empty_context();

--- a/source/tests/integration/json-model-generator/code/test_3/JsonModelGeneratorIntegrationTest3.java
+++ b/source/tests/integration/json-model-generator/code/test_3/JsonModelGeneratorIntegrationTest3.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.marianatrench.integrationtests;
+
+public class JsonModelGeneratorIntegrationTest3 {
+  int function(int a, int b) {
+    return a;
+  }
+
+  int functionB(
+      @TestParameterAnnotation("Annotate on the parameter") int a,
+      @TestParameterAnnotation("Annotate on the parameter") int b,
+      @TestParameterAnnotation("Annotate on the parameter") int c) {
+    return b;
+  }
+
+  static int functionC(
+      @TestParameterAnnotation("Annotate on the parameter") int a,
+      int b,
+      @TestParameterAnnotation("Annotate on the parameter") int c) {
+    return b;
+  }
+}

--- a/source/tests/integration/json-model-generator/code/test_3/TestParameterAnnotation.java
+++ b/source/tests/integration/json-model-generator/code/test_3/TestParameterAnnotation.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.marianatrench.integrationtests;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface TestParameterAnnotation {
+  String value() default "";
+}

--- a/source/tests/integration/json-model-generator/code/test_3/expected_output.json
+++ b/source/tests/integration/json-model-generator/code/test_3/expected_output.json
@@ -1,0 +1,61 @@
+// @generated
+{
+  "generations" : 
+  [
+    {
+      "port" : "Return",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Declaration",
+              "kind" : "SensitiveData",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/JsonModelGeneratorIntegrationTest3;.functionB:(III)I"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "method" : "Lcom/facebook/marianatrench/integrationtests/JsonModelGeneratorIntegrationTest3;.functionB:(III)I",
+  "position" : 
+  {
+    "line" : 18,
+    "path" : "com/facebook/marianatrench/integrationtests/JsonModelGeneratorIntegrationTest3.java"
+  }
+}
+{
+  "generations" : 
+  [
+    {
+      "port" : "Return",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Declaration",
+              "kind" : "SensitiveData",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/JsonModelGeneratorIntegrationTest3;.functionC:(III)I"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "method" : "Lcom/facebook/marianatrench/integrationtests/JsonModelGeneratorIntegrationTest3;.functionC:(III)I",
+  "position" : 
+  {
+    "line" : 25,
+    "path" : "com/facebook/marianatrench/integrationtests/JsonModelGeneratorIntegrationTest3.java"
+  }
+}

--- a/source/tests/integration/json-model-generator/code/test_3/model_generator.json
+++ b/source/tests/integration/json-model-generator/code/test_3/model_generator.json
@@ -1,0 +1,26 @@
+{
+  "model_generators": [
+    {
+      "find": "methods",
+      "where": [
+        {
+          "constraint": "any_parameter",
+          "inner": {
+            "constraint": "parameter_has_annotation",
+            "type": "Lcom/facebook/marianatrench/integrationtests/TestParameterAnnotation;",
+            "pattern": ".*"
+          }
+        }
+      ],
+        "model": {
+          "sources": [
+            {
+              "kind": "SensitiveData",
+              "port": "Return"
+            }
+          ]
+
+        }
+    }
+  ]
+}


### PR DESCRIPTION
### Summary 
This PR adds AnyParam constraint to MT DSL which basically a constraint that will be satisfied if any params match the inner constraint(s). Currently MT only supports one param constraint related to methods `NthParamConstraint` which checks if a param at a known location matches the inner constraint. In many cases we don't know the param location. 

The need for this is to differentiate between the following 2 methods

```
 @POST
 @Path("/loggedOutController")
 public Response LoggedOutController(@QueryParam String taint ) {
        sink(taint);
    ...
}

 @POST
 @Path("/LoggedInController")
 public Response LoggedInController(@Auth Props Session, @QueryParam String taint ) {
        sink(taint);
    ...
}
```

With this DSL we can say for any method that has no params with annotation `@Auth` add the feature `UnAuthenticated`

### Testing
Used the end to end and Integration Tests check 
* source/tests/integration/json-model-generator/code/test_3/JsonModelGeneratorIntegrationTest3.java
* source/model-generator/tests/MethodConstraintTest.cpp
To run locally
1. go to the build directory 
2. `make -j4 check`
Relevant logs
```
.............................................................................................................   Passed    0.01 sec
        Start 309: MethodConstraintTest.AnyParameterConstraintSatisfy
309/463 Test #309: MethodConstraintTest.AnyParameterConstraintSatisfy ......................................................................................
.............................................................................................................   Passed    0.01 sec
Start 462: JsonModelGeneratorIntegration/JsonModelGeneratorIntegrationTest.CompareModels/test_3  # GetParam() = "test_3"
462/463 Test #462: JsonModelGeneratorIntegration/JsonModelGeneratorIntegrationTest.CompareModels/test_3  # GetParam() = "test_3" ...........................
```

