### PR TITLE
Add minimal FP test

### DIFF
--- a/source/tests/integration/end-to-end/code/false_positives/FalsePositives.java
+++ b/source/tests/integration/end-to-end/code/false_positives/FalsePositives.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.marianatrench.integrationtests;
+
+public class FalsePositives {
+
+  // not expected to see a flow
+  public final void fp1_unexpected(UserBlob u) {
+    u.setF1("Not_tainted");
+    Origin.sink(u.getF1());
+  }
+
+  // expected to see a flow
+  public final void fp1_expected(UserBlob u) {
+    u.setF1("Not_tainted");
+    Origin.sink(u.getF2());
+  }
+}
+
+class UserBlob {
+  String f1;
+  String f2;
+  
+  public String getF1() {
+    return f1;
+  }
+  
+  public void setF1(String s) {
+    f1 = s;
+  }
+
+  public String getF2() {
+    return f2;
+  }
+  
+  public void setF2(String s) {
+    f2 = s;
+  }
+}

--- a/source/tests/integration/end-to-end/code/false_positives/expected_call_graph.json
+++ b/source/tests/integration/end-to-end/code/false_positives/expected_call_graph.json
@@ -1,0 +1,371 @@
+// @generated
+{
+  "Landroid/app/Activity;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Landroid/content/Context;.<init>:()V"
+    ]
+  },
+  "Landroid/app/Activity;.getIntent:()Landroid/content/Intent;" : 
+  {
+    "static" : 
+    [
+      "Landroid/content/Intent;.<init>:()V"
+    ]
+  },
+  "Landroid/content/ContentProvider;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/content/ContentProvider;.query:(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;" : 
+  {
+    "static" : 
+    [
+      "Landroid/database/Cursor;.<init>:()V"
+    ]
+  },
+  "Landroid/content/Context;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/content/Intent;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/content/Intent;.<init>:(Landroid/content/Context;Ljava/lang/Class;)V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/content/Intent;.<init>:(Ljava/lang/String;Landroid/net/Uri;)V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/content/Intent;.getBundleExtra:(Ljava/lang/String;)Landroid/os/Bundle;" : 
+  {
+    "static" : 
+    [
+      "Landroid/os/Bundle;.<init>:()V"
+    ]
+  },
+  "Landroid/content/Intent;.getData:()Landroid/net/Uri;" : 
+  {
+    "static" : 
+    [
+      "Landroid/net/Uri;.<init>:()V"
+    ]
+  },
+  "Landroid/content/Intent;.getExtras:()Landroid/os/Bundle;" : 
+  {
+    "static" : 
+    [
+      "Landroid/os/Bundle;.<init>:()V"
+    ]
+  },
+  "Landroid/database/Cursor;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/location/Location;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/net/Uri$Builder;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/net/Uri$Builder;.build:()Landroid/net/Uri;" : 
+  {
+    "static" : 
+    [
+      "Landroid/net/Uri;.<init>:(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"
+    ]
+  },
+  "Landroid/net/Uri;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/net/Uri;.<init>:(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/net/Uri;.parse:(Ljava/lang/String;)Landroid/net/Uri;" : 
+  {
+    "static" : 
+    [
+      "Landroid/net/Uri;.<init>:()V"
+    ]
+  },
+  "Landroid/net/Uri;.toString:()Ljava/lang/String;" : 
+  {
+    "virtual" : 
+    [
+      "Ljava/lang/String;.concat:(Ljava/lang/String;)Ljava/lang/String;"
+    ]
+  },
+  "Landroid/os/Bundle;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/text/TextUtils;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/util/Log;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroid/webkit/WebViewClient;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Landroidx/fragment/app/FragmentActivity;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Landroid/app/Activity;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/auth/datastore/LoggedInUserAuthDataStore;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/auth/datastore/LoggedInUserAuthDataStore;.getLoggedInUser:()Lcom/facebook/user/model/User;" : 
+  {
+    "static" : 
+    [
+      "Lcom/facebook/user/model/User;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/base/activity/FragmentBaseActivityUtil;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/base/activity/FragmentBaseActivityUtil;.getDefaultActivityIntent:()Landroid/content/Intent;" : 
+  {
+    "static" : 
+    [
+      "Landroid/content/Intent;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/content/SecureContextHelper;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_expected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V" : 
+  {
+    "static" : 
+    [
+      "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+    ],
+    "virtual" : 
+    [
+      "Lcom/facebook/marianatrench/integrationtests/UserBlob;.getF2:()Ljava/lang/String;",
+      "Lcom/facebook/marianatrench/integrationtests/UserBlob;.setF1:(Ljava/lang/String;)V"
+    ]
+  },
+  "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_unexpected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V" : 
+  {
+    "static" : 
+    [
+      "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+    ],
+    "virtual" : 
+    [
+      "Lcom/facebook/marianatrench/integrationtests/UserBlob;.getF1:()Ljava/lang/String;",
+      "Lcom/facebook/marianatrench/integrationtests/UserBlob;.setF1:(Ljava/lang/String;)V"
+    ]
+  },
+  "Lcom/facebook/marianatrench/integrationtests/Origin;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/marianatrench/integrationtests/Origin;.source:()Ljava/lang/Object;" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/marianatrench/integrationtests/UserBlob;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/secure/context/IntentLauncher;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/secure/context/SecureContextHelperV2;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/secure/context/SecureContextHelperV2;.get:()Lcom/facebook/secure/context/SecureContextHelperV2;" : 
+  {
+    "static" : 
+    [
+      "Lcom/facebook/secure/context/SecureContextHelperV2;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/secure/context/SecureContextHelperV2;.inAppBrowser:()Lcom/facebook/secure/context/IntentLauncher;" : 
+  {
+    "static" : 
+    [
+      "Lcom/facebook/secure/context/IntentLauncher;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/secure/context/SecureContextHelperV2;.internal:()Lcom/facebook/secure/context/IntentLauncher;" : 
+  {
+    "static" : 
+    [
+      "Lcom/facebook/secure/context/IntentLauncher;.<init>:()V"
+    ]
+  },
+  "Lcom/facebook/user/model/User;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/instagram/common/analytics/IgAnalyticsLogger;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/instagram/common/analytics/IgAnalyticsLogger;.getInstance:()Lcom/instagram/common/analytics/IgAnalyticsLogger;" : 
+  {
+    "static" : 
+    [
+      "Lcom/instagram/common/analytics/IgAnalyticsLogger;.<init>:()V"
+    ]
+  },
+  "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.obtain:(Ljava/lang/String;)Lcom/instagram/common/analytics/intf/AnalyticsEvent;" : 
+  {
+    "static" : 
+    [
+      "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.<init>:()V"
+    ]
+  },
+  "Ljava/lang/Integer;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Ljava/lang/String;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Ljava/lang/String;.concat:(Ljava/lang/String;)Ljava/lang/String;" : 
+  {
+    "virtual" : 
+    [
+      "Ljava/lang/String;.isEmpty:()Z"
+    ]
+  },
+  "Ljava/lang/Thread;.<init>:(Ljava/lang/Runnable;)V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  },
+  "Ljava/lang/Thread;.run:()V" : 
+  {
+    "virtual" : 
+    [
+      "Ljava/lang/Runnable;.run:()V",
+      "Ljava/lang/Thread;.run:()V"
+    ]
+  },
+  "Ljava/util/TreeMap;.<init>:()V" : 
+  {
+    "static" : 
+    [
+      "Ljava/lang/Object;.<init>:()V"
+    ]
+  }
+}

--- a/source/tests/integration/end-to-end/code/false_positives/expected_class_hierarchies.json
+++ b/source/tests/integration/end-to-end/code/false_positives/expected_class_hierarchies.json
@@ -1,0 +1,23 @@
+// @generated
+{
+  "extends" : 
+  {
+    "Landroid/app/Activity;" : 
+    [
+      "Landroidx/fragment/app/FragmentActivity;"
+    ],
+    "Landroid/content/Context;" : 
+    [
+      "Landroid/app/Activity;",
+      "Landroidx/fragment/app/FragmentActivity;"
+    ],
+    "Ljava/lang/Runnable;" : 
+    [
+      "Ljava/lang/Thread;"
+    ],
+    "Ljava/util/Map;" : 
+    [
+      "Ljava/util/TreeMap;"
+    ]
+  }
+}

--- a/source/tests/integration/end-to-end/code/false_positives/expected_dependencies.json
+++ b/source/tests/integration/end-to-end/code/false_positives/expected_dependencies.json
@@ -1,0 +1,122 @@
+// @generated
+{
+  "Landroid/app/Activity;.<init>:()V" : 
+  [
+    "Landroidx/fragment/app/FragmentActivity;.<init>:()V"
+  ],
+  "Landroid/content/Context;.<init>:()V" : 
+  [
+    "Landroid/app/Activity;.<init>:()V"
+  ],
+  "Landroid/content/Intent;.<init>:()V" : 
+  [
+    "Landroid/app/Activity;.getIntent:()Landroid/content/Intent;",
+    "Lcom/facebook/base/activity/FragmentBaseActivityUtil;.getDefaultActivityIntent:()Landroid/content/Intent;"
+  ],
+  "Landroid/database/Cursor;.<init>:()V" : 
+  [
+    "Landroid/content/ContentProvider;.query:(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;"
+  ],
+  "Landroid/net/Uri;.<init>:()V" : 
+  [
+    "Landroid/content/Intent;.getData:()Landroid/net/Uri;",
+    "Landroid/net/Uri;.parse:(Ljava/lang/String;)Landroid/net/Uri;"
+  ],
+  "Landroid/net/Uri;.<init>:(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V" : 
+  [
+    "Landroid/net/Uri$Builder;.build:()Landroid/net/Uri;"
+  ],
+  "Landroid/os/Bundle;.<init>:()V" : 
+  [
+    "Landroid/content/Intent;.getBundleExtra:(Ljava/lang/String;)Landroid/os/Bundle;",
+    "Landroid/content/Intent;.getExtras:()Landroid/os/Bundle;"
+  ],
+  "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V" : 
+  [
+    "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_expected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V",
+    "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_unexpected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+  ],
+  "Lcom/facebook/marianatrench/integrationtests/UserBlob;.getF1:()Ljava/lang/String;" : 
+  [
+    "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_unexpected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+  ],
+  "Lcom/facebook/marianatrench/integrationtests/UserBlob;.getF2:()Ljava/lang/String;" : 
+  [
+    "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_expected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+  ],
+  "Lcom/facebook/marianatrench/integrationtests/UserBlob;.setF1:(Ljava/lang/String;)V" : 
+  [
+    "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_expected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V",
+    "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_unexpected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+  ],
+  "Lcom/facebook/secure/context/IntentLauncher;.<init>:()V" : 
+  [
+    "Lcom/facebook/secure/context/SecureContextHelperV2;.inAppBrowser:()Lcom/facebook/secure/context/IntentLauncher;",
+    "Lcom/facebook/secure/context/SecureContextHelperV2;.internal:()Lcom/facebook/secure/context/IntentLauncher;"
+  ],
+  "Lcom/facebook/secure/context/SecureContextHelperV2;.<init>:()V" : 
+  [
+    "Lcom/facebook/secure/context/SecureContextHelperV2;.get:()Lcom/facebook/secure/context/SecureContextHelperV2;"
+  ],
+  "Lcom/facebook/user/model/User;.<init>:()V" : 
+  [
+    "Lcom/facebook/auth/datastore/LoggedInUserAuthDataStore;.getLoggedInUser:()Lcom/facebook/user/model/User;"
+  ],
+  "Lcom/instagram/common/analytics/IgAnalyticsLogger;.<init>:()V" : 
+  [
+    "Lcom/instagram/common/analytics/IgAnalyticsLogger;.getInstance:()Lcom/instagram/common/analytics/IgAnalyticsLogger;"
+  ],
+  "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.<init>:()V" : 
+  [
+    "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.obtain:(Ljava/lang/String;)Lcom/instagram/common/analytics/intf/AnalyticsEvent;"
+  ],
+  "Ljava/lang/Object;.<init>:()V" : 
+  [
+    "Landroid/content/ContentProvider;.<init>:()V",
+    "Landroid/content/Context;.<init>:()V",
+    "Landroid/content/Intent;.<init>:()V",
+    "Landroid/content/Intent;.<init>:(Landroid/content/Context;Ljava/lang/Class;)V",
+    "Landroid/content/Intent;.<init>:(Ljava/lang/String;Landroid/net/Uri;)V",
+    "Landroid/database/Cursor;.<init>:()V",
+    "Landroid/location/Location;.<init>:()V",
+    "Landroid/net/Uri$Builder;.<init>:()V",
+    "Landroid/net/Uri;.<init>:()V",
+    "Landroid/net/Uri;.<init>:(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+    "Landroid/os/Bundle;.<init>:()V",
+    "Landroid/text/TextUtils;.<init>:()V",
+    "Landroid/util/Log;.<init>:()V",
+    "Landroid/webkit/WebViewClient;.<init>:()V",
+    "Lcom/facebook/auth/datastore/LoggedInUserAuthDataStore;.<init>:()V",
+    "Lcom/facebook/base/activity/FragmentBaseActivityUtil;.<init>:()V",
+    "Lcom/facebook/content/SecureContextHelper;.<init>:()V",
+    "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.<init>:()V",
+    "Lcom/facebook/marianatrench/integrationtests/Origin;.<init>:()V",
+    "Lcom/facebook/marianatrench/integrationtests/Origin;.source:()Ljava/lang/Object;",
+    "Lcom/facebook/marianatrench/integrationtests/UserBlob;.<init>:()V",
+    "Lcom/facebook/secure/context/IntentLauncher;.<init>:()V",
+    "Lcom/facebook/secure/context/SecureContextHelperV2;.<init>:()V",
+    "Lcom/facebook/user/model/User;.<init>:()V",
+    "Lcom/instagram/common/analytics/IgAnalyticsLogger;.<init>:()V",
+    "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.<init>:()V",
+    "Ljava/lang/Integer;.<init>:()V",
+    "Ljava/lang/String;.<init>:()V",
+    "Ljava/lang/Thread;.<init>:(Ljava/lang/Runnable;)V",
+    "Ljava/util/TreeMap;.<init>:()V"
+  ],
+  "Ljava/lang/Runnable;.run:()V" : 
+  [
+    "Ljava/lang/Thread;.run:()V"
+  ],
+  "Ljava/lang/String;.concat:(Ljava/lang/String;)Ljava/lang/String;" : 
+  [
+    "Landroid/net/Uri;.toString:()Ljava/lang/String;"
+  ],
+  "Ljava/lang/String;.isEmpty:()Z" : 
+  [
+    "Ljava/lang/String;.concat:(Ljava/lang/String;)Ljava/lang/String;"
+  ],
+  "Ljava/lang/Thread;.run:()V" : 
+  [
+    "Ljava/lang/Thread;.run:()V"
+  ]
+}

--- a/source/tests/integration/end-to-end/code/false_positives/expected_output.json
+++ b/source/tests/integration/end-to-end/code/false_positives/expected_output.json
@@ -1,0 +1,1714 @@
+// @generated
+{
+  "method" : "Landroid/app/Activity;.<init>:()V",
+  "position" : 
+  {
+    "line" : 13
+  }
+}
+{
+  "method" : "Landroid/app/Activity;.getIntent:()Landroid/content/Intent;",
+  "position" : 
+  {
+    "line" : 22
+  }
+}
+{
+  "method" : "Landroid/app/Activity;.onCreate:()V",
+  "position" : 
+  {
+    "line" : 15
+  }
+}
+{
+  "method" : "Landroid/app/Activity;.onCreate:(Landroid/os/Bundle;)V",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Landroid/app/Activity;.onStart:()V",
+  "position" : 
+  {
+    "line" : 19
+  }
+}
+{
+  "method" : "Landroid/app/Activity;.startActivity:(Landroid/content/Intent;)V",
+  "position" : 
+  {
+    "line" : 26
+  }
+}
+{
+  "method" : "Landroid/content/ContentProvider;.<init>:()V",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Landroid/content/ContentProvider;.query:(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;",
+  "position" : 
+  {
+    "line" : 15
+  }
+}
+{
+  "method" : "Landroid/content/Context;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/content/Context;.startActivity:(Landroid/content/Intent;)V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.<init>:()V",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.<init>:(Landroid/content/Context;Ljava/lang/Class;)V",
+  "position" : 
+  {
+    "line" : 21
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.<init>:(Ljava/lang/String;Landroid/net/Uri;)V",
+  "position" : 
+  {
+    "line" : 19
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getBundleExtra:(Ljava/lang/String;)Landroid/os/Bundle;",
+  "position" : 
+  {
+    "line" : 58
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getData:()Landroid/net/Uri;",
+  "position" : 
+  {
+    "line" : 50
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getDataString:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 24
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getExtras:()Landroid/os/Bundle;",
+  "position" : 
+  {
+    "line" : 54
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getFlags:()I",
+  "position" : 
+  {
+    "line" : 28
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getIntExtra:(Ljava/lang/String;)I",
+  "position" : 
+  {
+    "line" : 42
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getIntExtra:(Ljava/lang/String;I)I",
+  "position" : 
+  {
+    "line" : 46
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getStringExtra:(Ljava/lang/String;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 38
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.hasExtra:(Ljava/lang/String;)Z",
+  "position" : 
+  {
+    "line" : 34
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.putExtra:(Ljava/lang/String;Ljava/lang/String;)V",
+  "position" : 
+  {
+    "line" : 65
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.putExtra:(Ljava/lang/String;Z)V",
+  "position" : 
+  {
+    "line" : 67
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.putExtras:(Landroid/os/Bundle;)V",
+  "position" : 
+  {
+    "line" : 63
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.setData:(Landroid/net/Uri;)V",
+  "modes" : [],
+  "position" : 
+  {
+    "line" : 61
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.setFlags:(I)V",
+  "modes" : [],
+  "position" : 
+  {
+    "line" : 31
+  }
+}
+{
+  "method" : "Landroid/database/Cursor;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Landroid/location/Location;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/location/Location;.getLatitude:()D",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Landroid/location/Location;.getLongitude:()D",
+  "position" : 
+  {
+    "line" : 16
+  }
+}
+{
+  "method" : "Landroid/location/Location;.toString:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 20
+  }
+}
+{
+  "method" : "Landroid/location/LocationListener;.onLocationChanged:(Landroid/location/Location;)V",
+  "modes" : 
+  [
+    "add-via-obscure-feature",
+    "skip-analysis"
+  ],
+  "position" : {}
+}
+{
+  "method" : "Landroid/net/Uri$Builder;.<init>:()V",
+  "position" : 
+  {
+    "line" : 51
+  }
+}
+{
+  "method" : "Landroid/net/Uri$Builder;.build:()Landroid/net/Uri;",
+  "position" : 
+  {
+    "line" : 72
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).host",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".host" : 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(0).path",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".path" : 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(0).scheme",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".scheme" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri$Builder;.host:(Ljava/lang/String;)Landroid/net/Uri$Builder;",
+  "position" : 
+  {
+    "line" : 62
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".host" : 3
+              }
+            }
+          ]
+        },
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".host" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri$Builder;.path:(Ljava/lang/String;)Landroid/net/Uri$Builder;",
+  "position" : 
+  {
+    "line" : 67
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".path" : 3
+              }
+            }
+          ]
+        },
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".path" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri$Builder;.scheme:(Ljava/lang/String;)Landroid/net/Uri$Builder;",
+  "position" : 
+  {
+    "line" : 54
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".scheme" : 3
+              }
+            }
+          ]
+        },
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".scheme" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri;.<init>:()V",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Landroid/net/Uri;.<init>:(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+  "position" : 
+  {
+    "line" : 16
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".scheme" : 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(2)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".host" : 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(3)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".path" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri;.decode:(Ljava/lang/String;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 27
+  }
+}
+{
+  "inline_as" : "Argument(0).host",
+  "method" : "Landroid/net/Uri;.getHost:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 35
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).host",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri;.getQueryParameter:(Ljava/lang/String;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 39
+  }
+}
+{
+  "inline_as" : "Argument(0).scheme",
+  "method" : "Landroid/net/Uri;.getScheme:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 31
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).scheme",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri;.parse:(Ljava/lang/String;)Landroid/net/Uri;",
+  "position" : 
+  {
+    "line" : 23
+  }
+}
+{
+  "method" : "Landroid/net/Uri;.toString:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 43
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).host",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(0).path",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(0).scheme",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/os/Bundle;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/os/Bundle;.containsKey:(Ljava/lang/String;)Z",
+  "position" : 
+  {
+    "line" : 20
+  }
+}
+{
+  "method" : "Landroid/os/Bundle;.getString:(Ljava/lang/String;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Landroid/os/Bundle;.putBoolean:(Ljava/lang/String;Ljava/lang/Boolean;)V",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Landroid/os/Bundle;.putString:(Ljava/lang/String;Ljava/lang/String;)V",
+  "position" : 
+  {
+    "line" : 15
+  }
+}
+{
+  "method" : "Landroid/text/TextUtils;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/text/TextUtils;.isEmpty:(Ljava/lang/String;)Z",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Landroid/util/Log;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/util/Log;.e:(Ljava/lang/String;Ljava/lang/String;)I",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Landroid/webkit/WebViewClient;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/webkit/WebViewClient;.onPageFinished:(Ljava/lang/String;)V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Landroidx/fragment/app/FragmentActivity;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Landroidx/fragment/app/FragmentActivity;.onActivityCreate:()V",
+  "position" : 
+  {
+    "line" : 13
+  }
+}
+{
+  "method" : "Lcom/facebook/auth/datastore/LoggedInUserAuthDataStore;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Lcom/facebook/auth/datastore/LoggedInUserAuthDataStore;.getLoggedInUser:()Lcom/facebook/user/model/User;",
+  "position" : 
+  {
+    "line" : 18
+  }
+}
+{
+  "method" : "Lcom/facebook/auth/datastore/LoggedInUserAuthDataStore;.isLoggedIn:()Z",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Lcom/facebook/base/activity/FragmentBaseActivityUtil;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Lcom/facebook/base/activity/FragmentBaseActivityUtil;.getDefaultActivityIntent:()Landroid/content/Intent;",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Lcom/facebook/content/SecureContextHelper;.<init>:()V",
+  "position" : 
+  {
+    "line" : 13
+  }
+}
+{
+  "method" : "Lcom/facebook/content/SecureContextHelper;.startFacebookActivity:(Landroid/content/Intent;Landroid/content/Context;)V",
+  "position" : 
+  {
+    "line" : 15
+  }
+}
+{
+  "method" : "Lcom/facebook/content/SecureContextHelper;.startFacebookActivityForResult:(Landroid/content/Intent;ILandroid/app/Activity;)V",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Lcom/facebook/content/SecureContextHelper;.startNonFacebookActivity:(Landroid/content/Intent;Landroid/content/Context;)V",
+  "position" : 
+  {
+    "line" : 19
+  }
+}
+{
+  "method" : "Lcom/facebook/content/SecureContextHelper;.startNonFacebookActivityForResult:(Landroid/content/Intent;ILandroid/app/Activity;)V",
+  "position" : 
+  {
+    "line" : 22
+  }
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9,
+    "path" : "FalsePositives.java"
+  }
+}
+{
+  "issues" : 
+  [
+    {
+      "callee" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+      "position" : 
+      {
+        "line" : 21,
+        "path" : "FalsePositives.java"
+      },
+      "rule" : 1,
+      "sink_index" : "0",
+      "sinks" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Sink",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+              ]
+            }
+          ],
+          "origin" : 
+          {
+            "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+            "position" : 
+            {
+              "end" : 24,
+              "line" : 21,
+              "path" : "FalsePositives.java",
+              "start" : 16
+            }
+          }
+        }
+      ],
+      "sources" : 
+      [
+        {
+          "call" : 
+          {
+            "position" : 
+            {
+              "line" : 19,
+              "path" : "FalsePositives.java"
+            }
+          },
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Source",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_expected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "method" : "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_expected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V",
+  "parameter_sources" : 
+  [
+    {
+      "port" : "Argument(1)",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Declaration",
+              "kind" : "Source",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_expected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "position" : 
+  {
+    "line" : 19,
+    "path" : "FalsePositives.java"
+  },
+  "sinks" : 
+  [
+    {
+      "port" : "Argument(1).f2",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Sink",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+              ]
+            }
+          ],
+          "origin" : 
+          {
+            "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+            "position" : 
+            {
+              "end" : 24,
+              "line" : 21,
+              "path" : "FalsePositives.java",
+              "start" : 16
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+{
+  "issues" : 
+  [
+    {
+      "callee" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+      "position" : 
+      {
+        "line" : 15,
+        "path" : "FalsePositives.java"
+      },
+      "rule" : 1,
+      "sink_index" : "0",
+      "sinks" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Sink",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+              ]
+            }
+          ],
+          "origin" : 
+          {
+            "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+            "position" : 
+            {
+              "end" : 24,
+              "line" : 15,
+              "path" : "FalsePositives.java",
+              "start" : 16
+            }
+          }
+        }
+      ],
+      "sources" : 
+      [
+        {
+          "call" : 
+          {
+            "position" : 
+            {
+              "line" : 13,
+              "path" : "FalsePositives.java"
+            }
+          },
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Source",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_unexpected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "method" : "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_unexpected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V",
+  "parameter_sources" : 
+  [
+    {
+      "port" : "Argument(1)",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Declaration",
+              "kind" : "Source",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_unexpected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "position" : 
+  {
+    "line" : 13,
+    "path" : "FalsePositives.java"
+  },
+  "sinks" : 
+  [
+    {
+      "port" : "Argument(1).f1",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Sink",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+              ]
+            }
+          ],
+          "origin" : 
+          {
+            "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+            "position" : 
+            {
+              "end" : 24,
+              "line" : 15,
+              "path" : "FalsePositives.java",
+              "start" : 16
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "inline_as" : "Argument(0)",
+  "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sanitize:(Ljava/lang/Object;)Ljava/lang/Object;",
+  "position" : 
+  {
+    "line" : 17
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+  "position" : 
+  {
+    "line" : 14
+  },
+  "sinks" : 
+  [
+    {
+      "port" : "Argument(0)",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Declaration",
+              "kind" : "Sink",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.source:()Ljava/lang/Object;",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/UserBlob;.<init>:()V",
+  "position" : 
+  {
+    "line" : 24,
+    "path" : "FalsePositives.java"
+  }
+}
+{
+  "inline_as" : "Argument(0).f1",
+  "method" : "Lcom/facebook/marianatrench/integrationtests/UserBlob;.getF1:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 29,
+    "path" : "FalsePositives.java"
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).f1",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "inline_as" : "Argument(0).f2",
+  "method" : "Lcom/facebook/marianatrench/integrationtests/UserBlob;.getF2:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 37,
+    "path" : "FalsePositives.java"
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).f2",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/UserBlob;.setF1:(Ljava/lang/String;)V",
+  "modes" : [],
+  "position" : 
+  {
+    "line" : 33,
+    "path" : "FalsePositives.java"
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".f1" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/UserBlob;.setF2:(Ljava/lang/String;)V",
+  "modes" : [],
+  "position" : 
+  {
+    "line" : 41,
+    "path" : "FalsePositives.java"
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".f2" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/secure/context/IntentLauncher;.<init>:()V",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Lcom/facebook/secure/context/IntentLauncher;.launchActivity:(Landroid/content/Intent;Landroid/content/Context;)Z",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Lcom/facebook/secure/context/SecureContextHelperV2;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Lcom/facebook/secure/context/SecureContextHelperV2;.get:()Lcom/facebook/secure/context/SecureContextHelperV2;",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Lcom/facebook/secure/context/SecureContextHelperV2;.inAppBrowser:()Lcom/facebook/secure/context/IntentLauncher;",
+  "position" : 
+  {
+    "line" : 22
+  }
+}
+{
+  "method" : "Lcom/facebook/secure/context/SecureContextHelperV2;.internal:()Lcom/facebook/secure/context/IntentLauncher;",
+  "position" : 
+  {
+    "line" : 18
+  }
+}
+{
+  "method" : "Lcom/facebook/user/model/User;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Lcom/facebook/user/model/User;.getId:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Lcom/instagram/common/analytics/IgAnalyticsLogger;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Lcom/instagram/common/analytics/IgAnalyticsLogger;.getInstance:()Lcom/instagram/common/analytics/IgAnalyticsLogger;",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Lcom/instagram/common/analytics/IgAnalyticsLogger;.reportEvent:(Lcom/instagram/common/analytics/intf/AnalyticsEvent;)V",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "inline_as" : "Argument(0)",
+  "method" : "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.addExtra:(Ljava/lang/String;Ljava/lang/String;)Lcom/instagram/common/analytics/intf/AnalyticsEvent;",
+  "position" : 
+  {
+    "line" : 16
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.obtain:(Ljava/lang/String;)Lcom/instagram/common/analytics/intf/AnalyticsEvent;",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Lcom/mariana_trench/artificial/ArrayAllocation;.allocateArray:(I)V",
+  "modes" : 
+  [
+    "skip-analysis"
+  ],
+  "position" : {}
+}
+{
+  "method" : "Ljava/lang/Integer;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Ljava/lang/Integer;.intValue:()I",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Ljava/lang/Object;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Ljava/lang/Object;.equals:(Ljava/lang/Object;)Z",
+  "position" : 
+  {
+    "line" : 16
+  }
+}
+{
+  "method" : "Ljava/lang/Object;.hashCode:()I",
+  "position" : 
+  {
+    "line" : 20
+  }
+}
+{
+  "method" : "Ljava/lang/Object;.toString:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Ljava/lang/Runnable;.run:()V",
+  "modes" : 
+  [
+    "add-via-obscure-feature",
+    "skip-analysis"
+  ],
+  "position" : {}
+}
+{
+  "method" : "Ljava/lang/String;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Ljava/lang/String;.charAt:(I)C",
+  "position" : 
+  {
+    "line" : 44
+  }
+}
+{
+  "method" : "Ljava/lang/String;.concat:(Ljava/lang/String;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 52
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Ljava/lang/String;.contains:(Ljava/lang/String;)Z",
+  "position" : 
+  {
+    "line" : 36
+  }
+}
+{
+  "method" : "Ljava/lang/String;.indexOf:(Ljava/lang/String;)I",
+  "position" : 
+  {
+    "line" : 24
+  }
+}
+{
+  "method" : "Ljava/lang/String;.isEmpty:()Z",
+  "position" : 
+  {
+    "line" : 40
+  }
+}
+{
+  "method" : "Ljava/lang/String;.length:()I",
+  "position" : 
+  {
+    "line" : 32
+  }
+}
+{
+  "method" : "Ljava/lang/String;.startsWith:(Ljava/lang/String;)Z",
+  "position" : 
+  {
+    "line" : 28
+  }
+}
+{
+  "method" : "Ljava/lang/String;.subSequence:(II)Ljava/lang/CharSequence;",
+  "position" : 
+  {
+    "line" : 48
+  }
+}
+{
+  "method" : "Ljava/lang/String;.substring:(I)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 16
+  }
+}
+{
+  "method" : "Ljava/lang/String;.substring:(II)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 20
+  }
+}
+{
+  "method" : "Ljava/lang/String;.valueOf:(Ljava/lang/Object;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Ljava/lang/Thread;.<init>:(Ljava/lang/Runnable;)V",
+  "position" : 
+  {
+    "line" : 13
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".target" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Ljava/lang/Thread;.run:()V",
+  "position" : 
+  {
+    "line" : 19
+  }
+}
+{
+  "method" : "Ljava/lang/Thread;.start:()V",
+  "position" : 
+  {
+    "line" : 24
+  }
+}
+{
+  "method" : "Ljava/util/Map;.put:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+  "modes" : 
+  [
+    "add-via-obscure-feature",
+    "skip-analysis"
+  ],
+  "position" : {}
+}
+{
+  "method" : "Ljava/util/TreeMap;.<init>:()V",
+  "position" : 
+  {
+    "line" : 10
+  }
+}
+{
+  "method" : "Ljava/util/TreeMap;.put:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+  "position" : 
+  {
+    "line" : 14
+  }
+}

--- a/source/tests/integration/end-to-end/code/false_positives/expected_output.json.actual
+++ b/source/tests/integration/end-to-end/code/false_positives/expected_output.json.actual
@@ -1,0 +1,1714 @@
+// @generated
+{
+  "method" : "Landroid/app/Activity;.<init>:()V",
+  "position" : 
+  {
+    "line" : 13
+  }
+}
+{
+  "method" : "Landroid/app/Activity;.getIntent:()Landroid/content/Intent;",
+  "position" : 
+  {
+    "line" : 22
+  }
+}
+{
+  "method" : "Landroid/app/Activity;.onCreate:()V",
+  "position" : 
+  {
+    "line" : 15
+  }
+}
+{
+  "method" : "Landroid/app/Activity;.onCreate:(Landroid/os/Bundle;)V",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Landroid/app/Activity;.onStart:()V",
+  "position" : 
+  {
+    "line" : 19
+  }
+}
+{
+  "method" : "Landroid/app/Activity;.startActivity:(Landroid/content/Intent;)V",
+  "position" : 
+  {
+    "line" : 26
+  }
+}
+{
+  "method" : "Landroid/content/ContentProvider;.<init>:()V",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Landroid/content/ContentProvider;.query:(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;",
+  "position" : 
+  {
+    "line" : 15
+  }
+}
+{
+  "method" : "Landroid/content/Context;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/content/Context;.startActivity:(Landroid/content/Intent;)V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.<init>:()V",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.<init>:(Landroid/content/Context;Ljava/lang/Class;)V",
+  "position" : 
+  {
+    "line" : 21
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.<init>:(Ljava/lang/String;Landroid/net/Uri;)V",
+  "position" : 
+  {
+    "line" : 19
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getBundleExtra:(Ljava/lang/String;)Landroid/os/Bundle;",
+  "position" : 
+  {
+    "line" : 58
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getData:()Landroid/net/Uri;",
+  "position" : 
+  {
+    "line" : 50
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getDataString:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 24
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getExtras:()Landroid/os/Bundle;",
+  "position" : 
+  {
+    "line" : 54
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getFlags:()I",
+  "position" : 
+  {
+    "line" : 28
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getIntExtra:(Ljava/lang/String;)I",
+  "position" : 
+  {
+    "line" : 42
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getIntExtra:(Ljava/lang/String;I)I",
+  "position" : 
+  {
+    "line" : 46
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.getStringExtra:(Ljava/lang/String;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 38
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.hasExtra:(Ljava/lang/String;)Z",
+  "position" : 
+  {
+    "line" : 34
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.putExtra:(Ljava/lang/String;Ljava/lang/String;)V",
+  "position" : 
+  {
+    "line" : 65
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.putExtra:(Ljava/lang/String;Z)V",
+  "position" : 
+  {
+    "line" : 67
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.putExtras:(Landroid/os/Bundle;)V",
+  "position" : 
+  {
+    "line" : 63
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.setData:(Landroid/net/Uri;)V",
+  "modes" : [],
+  "position" : 
+  {
+    "line" : 61
+  }
+}
+{
+  "method" : "Landroid/content/Intent;.setFlags:(I)V",
+  "modes" : [],
+  "position" : 
+  {
+    "line" : 31
+  }
+}
+{
+  "method" : "Landroid/database/Cursor;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Landroid/location/Location;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/location/Location;.getLatitude:()D",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Landroid/location/Location;.getLongitude:()D",
+  "position" : 
+  {
+    "line" : 16
+  }
+}
+{
+  "method" : "Landroid/location/Location;.toString:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 20
+  }
+}
+{
+  "method" : "Landroid/location/LocationListener;.onLocationChanged:(Landroid/location/Location;)V",
+  "modes" : 
+  [
+    "add-via-obscure-feature",
+    "skip-analysis"
+  ],
+  "position" : {}
+}
+{
+  "method" : "Landroid/net/Uri$Builder;.<init>:()V",
+  "position" : 
+  {
+    "line" : 51
+  }
+}
+{
+  "method" : "Landroid/net/Uri$Builder;.build:()Landroid/net/Uri;",
+  "position" : 
+  {
+    "line" : 72
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).host",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".host" : 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(0).path",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".path" : 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(0).scheme",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".scheme" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri$Builder;.host:(Ljava/lang/String;)Landroid/net/Uri$Builder;",
+  "position" : 
+  {
+    "line" : 62
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".host" : 3
+              }
+            }
+          ]
+        },
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".host" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri$Builder;.path:(Ljava/lang/String;)Landroid/net/Uri$Builder;",
+  "position" : 
+  {
+    "line" : 67
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".path" : 3
+              }
+            }
+          ]
+        },
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".path" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri$Builder;.scheme:(Ljava/lang/String;)Landroid/net/Uri$Builder;",
+  "position" : 
+  {
+    "line" : 54
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".scheme" : 3
+              }
+            }
+          ]
+        },
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                ".scheme" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri;.<init>:()V",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Landroid/net/Uri;.<init>:(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+  "position" : 
+  {
+    "line" : 16
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".scheme" : 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(2)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".host" : 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(3)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".path" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri;.decode:(Ljava/lang/String;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 27
+  }
+}
+{
+  "inline_as" : "Argument(0).host",
+  "method" : "Landroid/net/Uri;.getHost:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 35
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).host",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri;.getQueryParameter:(Ljava/lang/String;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 39
+  }
+}
+{
+  "inline_as" : "Argument(0).scheme",
+  "method" : "Landroid/net/Uri;.getScheme:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 31
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).scheme",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/net/Uri;.parse:(Ljava/lang/String;)Landroid/net/Uri;",
+  "position" : 
+  {
+    "line" : 23
+  }
+}
+{
+  "method" : "Landroid/net/Uri;.toString:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 43
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).host",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(0).path",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(0).scheme",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Landroid/os/Bundle;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/os/Bundle;.containsKey:(Ljava/lang/String;)Z",
+  "position" : 
+  {
+    "line" : 20
+  }
+}
+{
+  "method" : "Landroid/os/Bundle;.getString:(Ljava/lang/String;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Landroid/os/Bundle;.putBoolean:(Ljava/lang/String;Ljava/lang/Boolean;)V",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Landroid/os/Bundle;.putString:(Ljava/lang/String;Ljava/lang/String;)V",
+  "position" : 
+  {
+    "line" : 15
+  }
+}
+{
+  "method" : "Landroid/text/TextUtils;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/text/TextUtils;.isEmpty:(Ljava/lang/String;)Z",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Landroid/util/Log;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/util/Log;.e:(Ljava/lang/String;Ljava/lang/String;)I",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Landroid/webkit/WebViewClient;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Landroid/webkit/WebViewClient;.onPageFinished:(Ljava/lang/String;)V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Landroidx/fragment/app/FragmentActivity;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Landroidx/fragment/app/FragmentActivity;.onActivityCreate:()V",
+  "position" : 
+  {
+    "line" : 13
+  }
+}
+{
+  "method" : "Lcom/facebook/auth/datastore/LoggedInUserAuthDataStore;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Lcom/facebook/auth/datastore/LoggedInUserAuthDataStore;.getLoggedInUser:()Lcom/facebook/user/model/User;",
+  "position" : 
+  {
+    "line" : 18
+  }
+}
+{
+  "method" : "Lcom/facebook/auth/datastore/LoggedInUserAuthDataStore;.isLoggedIn:()Z",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Lcom/facebook/base/activity/FragmentBaseActivityUtil;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Lcom/facebook/base/activity/FragmentBaseActivityUtil;.getDefaultActivityIntent:()Landroid/content/Intent;",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Lcom/facebook/content/SecureContextHelper;.<init>:()V",
+  "position" : 
+  {
+    "line" : 13
+  }
+}
+{
+  "method" : "Lcom/facebook/content/SecureContextHelper;.startFacebookActivity:(Landroid/content/Intent;Landroid/content/Context;)V",
+  "position" : 
+  {
+    "line" : 15
+  }
+}
+{
+  "method" : "Lcom/facebook/content/SecureContextHelper;.startFacebookActivityForResult:(Landroid/content/Intent;ILandroid/app/Activity;)V",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Lcom/facebook/content/SecureContextHelper;.startNonFacebookActivity:(Landroid/content/Intent;Landroid/content/Context;)V",
+  "position" : 
+  {
+    "line" : 19
+  }
+}
+{
+  "method" : "Lcom/facebook/content/SecureContextHelper;.startNonFacebookActivityForResult:(Landroid/content/Intent;ILandroid/app/Activity;)V",
+  "position" : 
+  {
+    "line" : 22
+  }
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9,
+    "path" : "FalsePositives.java"
+  }
+}
+{
+  "issues" : 
+  [
+    {
+      "callee" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+      "position" : 
+      {
+        "line" : 21,
+        "path" : "FalsePositives.java"
+      },
+      "rule" : 1,
+      "sink_index" : "0",
+      "sinks" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Sink",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+              ]
+            }
+          ],
+          "origin" : 
+          {
+            "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+            "position" : 
+            {
+              "end" : 24,
+              "line" : 21,
+              "path" : "FalsePositives.java",
+              "start" : 16
+            }
+          }
+        }
+      ],
+      "sources" : 
+      [
+        {
+          "call" : 
+          {
+            "position" : 
+            {
+              "line" : 19,
+              "path" : "FalsePositives.java"
+            }
+          },
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Source",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_expected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "method" : "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_expected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V",
+  "parameter_sources" : 
+  [
+    {
+      "port" : "Argument(1)",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Declaration",
+              "kind" : "Source",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_expected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "position" : 
+  {
+    "line" : 19,
+    "path" : "FalsePositives.java"
+  },
+  "sinks" : 
+  [
+    {
+      "port" : "Argument(1).f2",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Sink",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+              ]
+            }
+          ],
+          "origin" : 
+          {
+            "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+            "position" : 
+            {
+              "end" : 24,
+              "line" : 21,
+              "path" : "FalsePositives.java",
+              "start" : 16
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+{
+  "issues" : 
+  [
+    {
+      "callee" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+      "position" : 
+      {
+        "line" : 15,
+        "path" : "FalsePositives.java"
+      },
+      "rule" : 1,
+      "sink_index" : "0",
+      "sinks" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Sink",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+              ]
+            }
+          ],
+          "origin" : 
+          {
+            "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+            "position" : 
+            {
+              "end" : 24,
+              "line" : 15,
+              "path" : "FalsePositives.java",
+              "start" : 16
+            }
+          }
+        }
+      ],
+      "sources" : 
+      [
+        {
+          "call" : 
+          {
+            "position" : 
+            {
+              "line" : 13,
+              "path" : "FalsePositives.java"
+            }
+          },
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Source",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_unexpected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "method" : "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_unexpected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V",
+  "parameter_sources" : 
+  [
+    {
+      "port" : "Argument(1)",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Declaration",
+              "kind" : "Source",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/FalsePositives;.fp1_unexpected:(Lcom/facebook/marianatrench/integrationtests/UserBlob;)V"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "position" : 
+  {
+    "line" : 13,
+    "path" : "FalsePositives.java"
+  },
+  "sinks" : 
+  [
+    {
+      "port" : "Argument(1).f1",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Origin",
+              "kind" : "Sink",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+              ]
+            }
+          ],
+          "origin" : 
+          {
+            "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+            "position" : 
+            {
+              "end" : 24,
+              "line" : 15,
+              "path" : "FalsePositives.java",
+              "start" : 16
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "inline_as" : "Argument(0)",
+  "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sanitize:(Ljava/lang/Object;)Ljava/lang/Object;",
+  "position" : 
+  {
+    "line" : 17
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+  "position" : 
+  {
+    "line" : 14
+  },
+  "sinks" : 
+  [
+    {
+      "port" : "Argument(0)",
+      "taint" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Declaration",
+              "kind" : "Sink",
+              "origins" : 
+              [
+                "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/Origin;.source:()Ljava/lang/Object;",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/UserBlob;.<init>:()V",
+  "position" : 
+  {
+    "line" : 24,
+    "path" : "FalsePositives.java"
+  }
+}
+{
+  "inline_as" : "Argument(0).f1",
+  "method" : "Lcom/facebook/marianatrench/integrationtests/UserBlob;.getF1:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 29,
+    "path" : "FalsePositives.java"
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).f1",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "inline_as" : "Argument(0).f2",
+  "method" : "Lcom/facebook/marianatrench/integrationtests/UserBlob;.getF2:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 37,
+    "path" : "FalsePositives.java"
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0).f2",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/UserBlob;.setF1:(Ljava/lang/String;)V",
+  "modes" : [],
+  "position" : 
+  {
+    "line" : 33,
+    "path" : "FalsePositives.java"
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".f1" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/marianatrench/integrationtests/UserBlob;.setF2:(Ljava/lang/String;)V",
+  "modes" : [],
+  "position" : 
+  {
+    "line" : 41,
+    "path" : "FalsePositives.java"
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".f2" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/facebook/secure/context/IntentLauncher;.<init>:()V",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Lcom/facebook/secure/context/IntentLauncher;.launchActivity:(Landroid/content/Intent;Landroid/content/Context;)Z",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Lcom/facebook/secure/context/SecureContextHelperV2;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Lcom/facebook/secure/context/SecureContextHelperV2;.get:()Lcom/facebook/secure/context/SecureContextHelperV2;",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Lcom/facebook/secure/context/SecureContextHelperV2;.inAppBrowser:()Lcom/facebook/secure/context/IntentLauncher;",
+  "position" : 
+  {
+    "line" : 22
+  }
+}
+{
+  "method" : "Lcom/facebook/secure/context/SecureContextHelperV2;.internal:()Lcom/facebook/secure/context/IntentLauncher;",
+  "position" : 
+  {
+    "line" : 18
+  }
+}
+{
+  "method" : "Lcom/facebook/user/model/User;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Lcom/facebook/user/model/User;.getId:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Lcom/instagram/common/analytics/IgAnalyticsLogger;.<init>:()V",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Lcom/instagram/common/analytics/IgAnalyticsLogger;.getInstance:()Lcom/instagram/common/analytics/IgAnalyticsLogger;",
+  "position" : 
+  {
+    "line" : 14
+  }
+}
+{
+  "method" : "Lcom/instagram/common/analytics/IgAnalyticsLogger;.reportEvent:(Lcom/instagram/common/analytics/intf/AnalyticsEvent;)V",
+  "position" : 
+  {
+    "line" : 17
+  }
+}
+{
+  "method" : "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "inline_as" : "Argument(0)",
+  "method" : "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.addExtra:(Ljava/lang/String;Ljava/lang/String;)Lcom/instagram/common/analytics/intf/AnalyticsEvent;",
+  "position" : 
+  {
+    "line" : 16
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Lcom/instagram/common/analytics/intf/AnalyticsEvent;.obtain:(Ljava/lang/String;)Lcom/instagram/common/analytics/intf/AnalyticsEvent;",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Lcom/mariana_trench/artificial/ArrayAllocation;.allocateArray:(I)V",
+  "modes" : 
+  [
+    "skip-analysis"
+  ],
+  "position" : {}
+}
+{
+  "method" : "Ljava/lang/Integer;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Ljava/lang/Integer;.intValue:()I",
+  "position" : 
+  {
+    "line" : 11
+  }
+}
+{
+  "method" : "Ljava/lang/Object;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Ljava/lang/Object;.equals:(Ljava/lang/Object;)Z",
+  "position" : 
+  {
+    "line" : 16
+  }
+}
+{
+  "method" : "Ljava/lang/Object;.hashCode:()I",
+  "position" : 
+  {
+    "line" : 20
+  }
+}
+{
+  "method" : "Ljava/lang/Object;.toString:()Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Ljava/lang/Runnable;.run:()V",
+  "modes" : 
+  [
+    "add-via-obscure-feature",
+    "skip-analysis"
+  ],
+  "position" : {}
+}
+{
+  "method" : "Ljava/lang/String;.<init>:()V",
+  "position" : 
+  {
+    "line" : 9
+  }
+}
+{
+  "method" : "Ljava/lang/String;.charAt:(I)C",
+  "position" : 
+  {
+    "line" : 44
+  }
+}
+{
+  "method" : "Ljava/lang/String;.concat:(Ljava/lang/String;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 52
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(0)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalReturn",
+              "output_paths" : 
+              {
+                "" : 4
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Ljava/lang/String;.contains:(Ljava/lang/String;)Z",
+  "position" : 
+  {
+    "line" : 36
+  }
+}
+{
+  "method" : "Ljava/lang/String;.indexOf:(Ljava/lang/String;)I",
+  "position" : 
+  {
+    "line" : 24
+  }
+}
+{
+  "method" : "Ljava/lang/String;.isEmpty:()Z",
+  "position" : 
+  {
+    "line" : 40
+  }
+}
+{
+  "method" : "Ljava/lang/String;.length:()I",
+  "position" : 
+  {
+    "line" : 32
+  }
+}
+{
+  "method" : "Ljava/lang/String;.startsWith:(Ljava/lang/String;)Z",
+  "position" : 
+  {
+    "line" : 28
+  }
+}
+{
+  "method" : "Ljava/lang/String;.subSequence:(II)Ljava/lang/CharSequence;",
+  "position" : 
+  {
+    "line" : 48
+  }
+}
+{
+  "method" : "Ljava/lang/String;.substring:(I)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 16
+  }
+}
+{
+  "method" : "Ljava/lang/String;.substring:(II)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 20
+  }
+}
+{
+  "method" : "Ljava/lang/String;.valueOf:(Ljava/lang/Object;)Ljava/lang/String;",
+  "position" : 
+  {
+    "line" : 12
+  }
+}
+{
+  "method" : "Ljava/lang/Thread;.<init>:(Ljava/lang/Runnable;)V",
+  "position" : 
+  {
+    "line" : 13
+  },
+  "propagation" : 
+  [
+    {
+      "input" : "Argument(1)",
+      "output" : 
+      [
+        {
+          "kinds" : 
+          [
+            {
+              "call_info" : "Propagation",
+              "kind" : "LocalArgument(0)",
+              "output_paths" : 
+              {
+                ".target" : 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{
+  "method" : "Ljava/lang/Thread;.run:()V",
+  "position" : 
+  {
+    "line" : 19
+  }
+}
+{
+  "method" : "Ljava/lang/Thread;.start:()V",
+  "position" : 
+  {
+    "line" : 24
+  }
+}
+{
+  "method" : "Ljava/util/Map;.put:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+  "modes" : 
+  [
+    "add-via-obscure-feature",
+    "skip-analysis"
+  ],
+  "position" : {}
+}
+{
+  "method" : "Ljava/util/TreeMap;.<init>:()V",
+  "position" : 
+  {
+    "line" : 10
+  }
+}
+{
+  "method" : "Ljava/util/TreeMap;.put:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+  "position" : 
+  {
+    "line" : 14
+  }
+}

--- a/source/tests/integration/end-to-end/code/false_positives/expected_overrides.json
+++ b/source/tests/integration/end-to-end/code/false_positives/expected_overrides.json
@@ -1,0 +1,20 @@
+// @generated
+{
+  "Landroid/content/Context;.startActivity:(Landroid/content/Intent;)V" : 
+  [
+    "Landroid/app/Activity;.startActivity:(Landroid/content/Intent;)V"
+  ],
+  "Ljava/lang/Object;.toString:()Ljava/lang/String;" : 
+  [
+    "Landroid/location/Location;.toString:()Ljava/lang/String;",
+    "Landroid/net/Uri;.toString:()Ljava/lang/String;"
+  ],
+  "Ljava/lang/Runnable;.run:()V" : 
+  [
+    "Ljava/lang/Thread;.run:()V"
+  ],
+  "Ljava/util/Map;.put:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;" : 
+  [
+    "Ljava/util/TreeMap;.put:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  ]
+}

--- a/source/tests/integration/end-to-end/code/false_positives/model_generators.json
+++ b/source/tests/integration/end-to-end/code/false_positives/model_generators.json
@@ -1,0 +1,59 @@
+{
+  "model_generators": [
+    {
+      "find": "methods",
+      "where": [
+        {
+          "constraint": "signature_pattern",
+          "pattern": ".*integrationtests/FalsePositives;.fp1.*"
+        }
+      ],
+      "model": {
+        "for_all_parameters": [
+          {
+            "variable": "x",
+            "where": [
+            ],
+            "parameter_sources": [
+              {
+                "port": "Argument(x)",
+                "kind": "Source"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "find": "methods",
+      "_comment": "Update the analysis mode for setter's like function to have strong-write-on-propagation",
+      "where": [
+        {
+          "constraint": "any_of",
+          "inners": [
+            {
+              "constraint": "name",
+              "pattern": "^set.*"
+            }
+          ]
+        },
+        {
+          "constraint": "visibility",
+          "is": "public"
+        },
+        {
+          "constraint": "return",
+          "inner": {
+            "constraint": "name",
+            "pattern": "V"
+          }
+        }
+      ],
+      "model": {
+        "modes": [
+          "strong-write-on-propagation"
+        ]
+      }
+    }
+  ]
+}

--- a/source/tests/integration/end-to-end/code/false_positives/models.json
+++ b/source/tests/integration/end-to-end/code/false_positives/models.json
@@ -1,0 +1,11 @@
+[
+  {
+    "method": "Lcom/facebook/marianatrench/integrationtests/Origin;.sink:(Ljava/lang/Object;)V",
+    "sinks": [
+      {
+        "kind": "Sink",
+        "port": "Argument(0)"
+      }
+    ]
+  }
+]

--- a/source/tests/integration/end-to-end/code/false_positives/rules.json
+++ b/source/tests/integration/end-to-end/code/false_positives/rules.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "Flow",
+    "code": 1,
+    "description": "",
+    "sources": [
+      "Source"
+    ],
+    "sinks": [
+      "Sink"
+    ]
+  }
+]


### PR DESCRIPTION
### Summary
This is a minimal test showing a false positives when the DSL mark params as sources but then there is a `setter` that should override the taint 
Example code
```
  public final void fp1_expected(UserBlob u) {
    u.setF1("Not_tainted");
    Origin.sink(u.getF2());
  }
```

### Testing
Added an e2e test demonstrating the FP 