### PR TITLE
Fix path to str conversion in JsonValidation

### DIFF
--- a/source/JsonValidation.cpp
+++ b/source/JsonValidation.cpp
@@ -275,7 +275,7 @@ Json::Value JsonValidation::parse_json_file(
   std::ifstream file;
   file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
   try {
-    file.open(path, std::ios_base::binary);
+    file.open(path.c_str(), std::ios_base::binary);
   } catch (const std::ifstream::failure&) {
     ERROR(1, "Could not open json file: `{}`.", path.string());
     throw;
@@ -327,7 +327,7 @@ void JsonValidation::write_json_file(
     const Json::Value& value) {
   std::ofstream file;
   file.exceptions(std::ofstream::failbit | std::ofstream::badbit);
-  file.open(path, std::ios_base::binary);
+  file.open(path.c_str(), std::ios_base::binary);
   compact_writer()->write(value, &file);
   file << "\n";
   file.close();


### PR DESCRIPTION
Change: Just call c_str() on a couple of boost path objects.

Reason: The implicit conversion of a boost path to a "string-like" type might or not work depending on the platform. While code without this change builds correctly in Ubuntu, it might fail on Mac platforms, giving errors like:
```
2024-01-05T16:23:00.4575200Z /Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk/usr/include/c++/v1/__config:810:49: note: expanded from macro '_LIBCPP_DEPRECATED'
2024-01-05T16:23:00.4576200Z #      define _LIBCPP_DEPRECATED __attribute__((deprecated))
2024-01-05T16:23:00.4576800Z                                                 ^
2024-01-05T16:23:00.4578660Z /Users/runner/work/mariana-trench/mariana-trench/source/JsonValidation.cpp:278:10: error: no matching member function for call to 'open'
2024-01-05T16:23:00.4579310Z     file.open(path, std::ios_base::binary);
```

By having an explicit conversion, the problem is avoided.