### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/desugar/com/facebook/marianatrench/tests/MethodHandlerVisitorTest.java
+++ b/desugar/com/facebook/marianatrench/tests/MethodHandlerVisitorTest.java
@@ -25,7 +25,8 @@ public class MethodHandlerVisitorTest {
     String inputClassString = BytecodeProcessing.bytecodeMethodsToString(inputClass);
     String inputClassStringDesugared =
         inputClassString.replace(
-            "INVOKEVIRTUAL java/lang/invoke/MethodHandle.invokeExact (Ljava/lang/String;CC)Ljava/lang/String;",
+            "INVOKEVIRTUAL java/lang/invoke/MethodHandle.invokeExact"
+                + " (Ljava/lang/String;CC)Ljava/lang/String;",
             "POP\n    POP\n    POP");
     String outputClassString = BytecodeProcessing.bytecodeMethodsToString(writer.toByteArray());
     assertThat(inputClassStringDesugared).isEqualTo(outputClassString);

--- a/source/tests/integration/end-to-end/code/broadening/Flow.java
+++ b/source/tests/integration/end-to-end/code/broadening/Flow.java
@@ -46,7 +46,7 @@ public class Flow {
     public Tree c;
     public Tree d;
     public Tree e;
-  };
+  }
 
   public Tree widened_source_sink_depth(Tree argument) {
     Origin.sink(argument.a.b.c.d.e);

--- a/source/tests/integration/end-to-end/code/return_sink/Flow.java
+++ b/source/tests/integration/end-to-end/code/return_sink/Flow.java
@@ -34,7 +34,7 @@ public class Flow {
   private static class Tree {
     public Tree foo;
     public Tree bar;
-  };
+  }
 
   static Tree return_sink_foo(Tree tree) {
     return tree;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


