### PR TITLE
Configurable heuristics parameters

### DIFF
--- a/documentation/website/documentation/configuration.md
+++ b/documentation/website/documentation/configuration.md
@@ -69,58 +69,58 @@ Mariana Trench uses various heuristics parameters during the analysis. It is pos
 
 ## Heuristics Parameters
 
-#### `k_join_override_threshold INT`
+#### `join_override_threshold INT`
 When a method has a set of overrides greater than this threshold, Mariana Trench does not join all overrides at call sites.
 
-#### `k_android_join_override_threshold INT`
+#### `android_join_override_threshold INT`
 When an android/java/google method has a set of overrides which is greater than this threshold, Mariana Trench does not join all overrides at call sites.
 
-#### `k_warn_override_threshold INT`
+#### `warn_override_threshold INT`
 When a method which has a set of overrides greater than this threshold that is not marked with `NoJoinVirtualOverrides` is called at least once, Mariana Trench prints a warning.
 
-#### `k_generation_max_port_size INT`
+#### `generation_max_port_size INT`
 Maximum size of the port of a generation.
 
-#### `k_generation_max_output_path_leaves INT`
+#### `generation_max_output_path_leaves INT`
 Maximum number of leaves in the tree of output paths of generations. When reaching the maximum, Mariana Trench collapses all the subtrees into a single node.
 
-#### `k_parameter_source_max_port_size INT`
+#### `parameter_source_max_port_size INT`
 Maximum size of the port of a parameter source.
 
-#### `k_parameter_source_max_output_path_leaves INT`
+#### `parameter_source_max_output_path_leaves INT`
 Maximum number of leaves in the tree of output paths of parameter sources. When reaching the maximum, Mariana Trench collapses all the subtrees into a single node.
 
-#### `k_sink_max_port_size INT`
+#### `sink_max_port_size INT`
 Maximum size of the port of a sink.
 
-#### `k_sink_max_input_path_leaves INT`
+#### `sink_max_input_path_leaves INT`
 Maximum number of leaves in the tree of input paths of sinks. When reaching the maximum, Mariana Trench collapses all the subtrees into a single node.
 
-#### `k_call_effect_source_max_port_size INT`
+#### `call_effect_source_max_port_size INT`
 Maximum size of the port of a call effect source.
 
-#### `k_call_effect_source_max_output_path_leaves INT`
+#### `call_effect_source_max_output_path_leaves INT`
 Maximum number of leaves in the tree of output paths of call effect sources. When reaching the maximum, Mariana Trench collapses all the subtrees into a single node.
 
-#### `k_call_effect_sink_max_port_size INT`
+#### `call_effect_sink_max_port_size INT`
 Maximum size of the port of a call effect sink.
 
-#### `k_call_effect_sink_max_input_path_leaves INT`
+#### `call_effect_sink_max_input_path_leaves INT`
 Maximum number of leaves in the tree of input paths of call effect sinks. When reaching the maximum, Mariana Trench collapses all the subtrees into a single node.
 
-#### `k_max_number_iterations INT`
+#### `max_number_iterations INT`
 Maximum number of global iterations before Mariana Trench aborts the analysis.
 
-#### `k_max_depth_class_properties INT`
+#### `max_depth_class_properties INT`
 Maximum depth of dependency graph traversal to find class properties.
 
-#### `k_max_call_chain_source_sink_distance INT`
+#### `max_call_chain_source_sink_distance INT`
 Maximum number of hops that can be tracked for a call chain issue.
 
-#### `k_propagation_max_input_path_size INT`
+#### `propagation_max_input_path_size INT`
 Maximum size of the input access path of a propagation.
 
-#### `k_propagation_max_input_path_leaves INT`
+#### `propagation_max_input_path_leaves INT`
 Maximum number of leaves in the tree of input paths of propagations.
 
 ### Heuristics Parameter Configuration Example
@@ -129,23 +129,23 @@ The following JSON document is a valid configuration file for the heuristics par
 It improves the precision of the analysis by sacrificing some performance.
 ```json
 {
-    "k_join_override_threshold": 100,
-    "k_android_join_override_threshold": 100,
-    "k_warn_override_threshold": 100,
-    "k_generation_max_port_size": 10,
-    "k_generation_max_output_path_leaves": 30,
-    "k_parameter_source_max_port_size": 10,
-    "k_parameter_source_max_output_path_leaves": 30,
-    "k_sink_max_port_size": 10,
-    "k_sink_max_input_path_leaves": 30,
-    "k_call_effect_source_max_port_size": 10,
-    "k_call_effect_source_max_output_path_leaves": 30,
-    "k_call_effect_sink_max_port_size": 10,
-    "k_call_effect_sink_max_input_path_leaves": 30,
-    "k_max_number_iterations": 300,
-    "k_max_depth_class_properties": 30,
-    "k_max_call_chain_source_sink_distance": 30,
-    "k_propagation_max_input_path_size": 10,
-    "k_propagation_max_input_path_leaves": 10
+    "join_override_threshold": 100,
+    "android_join_override_threshold": 100,
+    "warn_override_threshold": 100,
+    "generation_max_port_size": 10,
+    "generation_max_output_path_leaves": 30,
+    "parameter_source_max_port_size": 10,
+    "parameter_source_max_output_path_leaves": 30,
+    "sink_max_port_size": 10,
+    "sink_max_input_path_leaves": 30,
+    "call_effect_source_max_port_size": 10,
+    "call_effect_source_max_output_path_leaves": 30,
+    "call_effect_sink_max_port_size": 10,
+    "call_effect_sink_max_input_path_leaves": 30,
+    "max_number_iterations": 300,
+    "max_depth_class_properties": 30,
+    "max_call_chain_source_sink_distance": 30,
+    "propagation_max_input_path_size": 10,
+    "propagation_max_input_path_leaves": 10
 }
 ```

--- a/documentation/website/documentation/configuration.md
+++ b/documentation/website/documentation/configuration.md
@@ -63,3 +63,89 @@ A `;` separated search path where Mariana Trench will try to find the model gene
 
 #### `--maximum-source-sink-distance MAXIMUM_SOURCE_SINK_DISTANCE`
 For performance reasons it can be useful to limit the maximum length of a trace Mariana Trench tries to find (note that longer traces also tend to be harder to interpret). Due to the modular nature of the analysis the value specified here limits the maximum length from the trace root to the source, and from the trace root to the sink. This means found traces can have length of `2 x MAXIMUM_SOURCE_SINK_DISTANCE`.
+
+#### `--heuristics HEURISTICS_FILE_PATH`
+Mariana Trench uses various heuristics parameters during the analysis. It is possible to set some of them with a JSON configuration file. The complete list of configurable parameters is reported in the [heuristics parameters section](#heuristics-parameters). It is optional to specify a configuration for the heuristics parameters, and the the parameters that are not specified are set to a default value.
+
+## Heuristics Parameters
+
+#### `k_join_override_threshold INT`
+When a method has a set of overrides greater than this threshold, Mariana Trench does not join all overrides at call sites.
+
+#### `k_android_join_override_threshold INT`
+When an android/java/google method has a set of overrides which is greater than this threshold, Mariana Trench does not join all overrides at call sites.
+
+#### `k_warn_override_threshold INT`
+When a method which has a set of overrides greater than this threshold that is not marked with `NoJoinVirtualOverrides` is called at least once, Mariana Trench prints a warning.
+
+#### `k_generation_max_port_size INT`
+Maximum size of the port of a generation.
+
+#### `k_generation_max_output_path_leaves INT`
+Maximum number of leaves in the tree of output paths of generations. When reaching the maximum, Mariana Trench collapses all the subtrees into a single node.
+
+#### `k_parameter_source_max_port_size INT`
+Maximum size of the port of a parameter source.
+
+#### `k_parameter_source_max_output_path_leaves INT`
+Maximum number of leaves in the tree of output paths of parameter sources. When reaching the maximum, Mariana Trench collapses all the subtrees into a single node.
+
+#### `k_sink_max_port_size INT`
+Maximum size of the port of a sink.
+
+#### `k_sink_max_input_path_leaves INT`
+Maximum number of leaves in the tree of input paths of sinks. When reaching the maximum, Mariana Trench collapses all the subtrees into a single node.
+
+#### `k_call_effect_source_max_port_size INT`
+Maximum size of the port of a call effect source.
+
+#### `k_call_effect_source_max_output_path_leaves INT`
+Maximum number of leaves in the tree of output paths of call effect sources. When reaching the maximum, Mariana Trench collapses all the subtrees into a single node.
+
+#### `k_call_effect_sink_max_port_size INT`
+Maximum size of the port of a call effect sink.
+
+#### `k_call_effect_sink_max_input_path_leaves INT`
+Maximum number of leaves in the tree of input paths of call effect sinks. When reaching the maximum, Mariana Trench collapses all the subtrees into a single node.
+
+#### `k_max_number_iterations INT`
+Maximum number of global iterations before Mariana Trench aborts the analysis.
+
+#### `k_max_depth_class_properties INT`
+Maximum depth of dependency graph traversal to find class properties.
+
+#### `k_max_call_chain_source_sink_distance INT`
+Maximum number of hops that can be tracked for a call chain issue.
+
+#### `k_propagation_max_input_path_size INT`
+Maximum size of the input access path of a propagation.
+
+#### `k_propagation_max_input_path_leaves INT`
+Maximum number of leaves in the tree of input paths of propagations.
+
+### Heuristics Parameter Configuration Example
+
+The following JSON document is a valid configuration file for the heuristics parameters.
+It improves the precision of the analysis by sacrificing some performance.
+```json
+{
+    "k_join_override_threshold": 100,
+    "k_android_join_override_threshold": 100,
+    "k_warn_override_threshold": 100,
+    "k_generation_max_port_size": 10,
+    "k_generation_max_output_path_leaves": 30,
+    "k_parameter_source_max_port_size": 10,
+    "k_parameter_source_max_output_path_leaves": 30,
+    "k_sink_max_port_size": 10,
+    "k_sink_max_input_path_leaves": 30,
+    "k_call_effect_source_max_port_size": 10,
+    "k_call_effect_source_max_output_path_leaves": 30,
+    "k_call_effect_sink_max_port_size": 10,
+    "k_call_effect_sink_max_input_path_leaves": 30,
+    "k_max_number_iterations": 300,
+    "k_max_depth_class_properties": 30,
+    "k_max_call_chain_source_sink_distance": 30,
+    "k_propagation_max_input_path_size": 10,
+    "k_propagation_max_input_path_leaves": 10
+}
+```

--- a/shim/shim.py
+++ b/shim/shim.py
@@ -83,21 +83,16 @@ def _system_jar_configuration_path(input: str) -> str:
     return input
 
 def _heuristics_json_config_exists(input: str) -> str:
-    if input.endswith(".json"):
-        path = _path_exists(input)
-        with open(path) as file:
-            try:
-                # Heuristics are a list of key-value pairs.
-                safe_json.load(file, Dict[str, Any])
-                return path
-            except safe_json.InvalidJson:
-                raise argparse.ArgumentTypeError(
-                    f"`{path}` must be a valid JSON file with key-value pairs"
-                )
-    else:
-        raise argparse.ArgumentTypeError(
-            f"`{input}` must be a JSON file"
-        )
+    path = _path_exists(input)
+    with open(path) as file:
+        try:
+            # Heuristics are a list of key-value pairs.
+            safe_json.load(file, Dict[str, Any])
+            return path
+        except safe_json.InvalidJson:
+            raise argparse.ArgumentTypeError(
+                f"`{path}` must be a valid JSON file with key-value pairs"
+            )
 
 class ExtractJexException(ClientError):
     pass

--- a/shim/shim.py
+++ b/shim/shim.py
@@ -15,7 +15,7 @@ import sys
 import tempfile
 import traceback
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Dict
 from zipfile import BadZipFile
 
 from pyre_extensions import none_throws, safe_json
@@ -75,13 +75,29 @@ def _system_jar_configuration_path(input: str) -> str:
                 return ";".join(paths)
             except safe_json.InvalidJson:
                 raise argparse.ArgumentTypeError(
-                    f"`{path} must contain a list of strings"
+                    f"`{path}` must contain a list of strings"
                 )
 
     # Validation deferred to backend if we pass `;` separated list of paths
     # because they are allowed to not exist.
     return input
 
+def _heuristics_json_config_exists(input: str) -> str:
+    if input.endswith(".json"):
+        path = _path_exists(input)
+        with open(path) as file:
+            try:
+                # Heuristics are a list of key-value pairs.
+                safe_json.load(file, Dict[str, Any])
+                return path
+            except safe_json.InvalidJson:
+                raise argparse.ArgumentTypeError(
+                    f"`{path}` must be a valid JSON file with key-value pairs"
+                )
+    else:
+        raise argparse.ArgumentTypeError(
+            f"`{input}` must be a JSON file"
+        )
 
 class ExtractJexException(ClientError):
     pass
@@ -462,6 +478,15 @@ def _add_configuration_arguments(parser: argparse.ArgumentParser) -> None:
             "method invocations for all other object type arguments as well."
         ),
     )
+    configuration_arguments.add_argument(
+        "--heuristics",
+        type=_heuristics_json_config_exists,
+        help=(
+            "Path to JSON configuration file which specifies heuristics "
+            "parameters to use during the analysis. See the documentation for "
+            "available heuristics parameters."
+        ),
+    )
 
 
 def _add_analysis_arguments(parser: argparse.ArgumentParser) -> None:
@@ -666,6 +691,10 @@ def _get_command_options(
     if arguments.allow_via_cast_feature:
         for feature in arguments.allow_via_cast_feature:
             options.append("--allow-via-cast-feature=%s" % feature.strip())
+
+    if arguments.heuristics:
+        options.append("--heuristics")
+        options.append(arguments.heuristics)
 
     if arguments.sequential:
         options.append("--sequential")

--- a/source/ArtificialMethods.cpp
+++ b/source/ArtificialMethods.cpp
@@ -60,7 +60,8 @@ std::vector<Model> ArtificialMethods::models(Context& context) const {
           /* output_paths */ {},
           /* local_positions */ {},
           /* locally_inferred_features */ FeatureMayAlwaysSet::bottom(),
-          /* extra_traces */ {}));
+          /* extra_traces */ {}),
+      context.options->heuristics());
   models.push_back(model);
 
   return models;

--- a/source/BackwardTaintTransfer.cpp
+++ b/source/BackwardTaintTransfer.cpp
@@ -155,10 +155,16 @@ void infer_input_taint(
       LOG_OR_DUMP(context, 4, "Inferred sink for port {}: {}", port, sinks);
       if (port.root().is_call_effect()) {
         context->new_model.add_inferred_call_effect_sinks(
-            std::move(port), std::move(sinks), widening_features);
+            std::move(port),
+            std::move(sinks),
+            widening_features,
+            context->options.heuristics());
       } else {
         context->new_model.add_inferred_sinks(
-            std::move(port), std::move(sinks), widening_features);
+            std::move(port),
+            std::move(sinks),
+            widening_features,
+            context->options.heuristics());
       }
     }
 
@@ -208,7 +214,10 @@ void infer_input_taint(
           port,
           propagations);
       context->new_model.add_inferred_propagations(
-          std::move(port), std::move(propagations), widening_features);
+          std::move(port),
+          std::move(propagations),
+          widening_features,
+          context->options.heuristics());
     }
   }
 }

--- a/source/CallGraph.cpp
+++ b/source/CallGraph.cpp
@@ -484,7 +484,7 @@ void process_shim_lifecycle(
         caller->show());
     return;
   } else if (
-      target_lifecycle_methods.size() >= heuristics.k_join_override_threshold()) {
+      target_lifecycle_methods.size() >= heuristics.join_override_threshold()) {
     // Although this is not a join, shimming to the derived life-cycle methods
     // simulates the joining the models of these as if they were virtual
     // overrides. Besides, if there is a large number of overrides, there will
@@ -497,7 +497,7 @@ void process_shim_lifecycle(
         target_lifecycle_methods.size(),
         show(instruction),
         caller->show(),
-        heuristics.k_join_override_threshold());
+        heuristics.join_override_threshold());
     return;
   }
 

--- a/source/CallGraph.cpp
+++ b/source/CallGraph.cpp
@@ -446,7 +446,8 @@ void process_shim_lifecycle(
     const FeatureFactory& feature_factory,
     std::unordered_map<std::string, TextualOrderIndex>&
         sink_textual_order_index,
-    std::vector<ArtificialCallee>& artificial_callees) {
+    std::vector<ArtificialCallee>& artificial_callees,
+    const Heuristics& heuristics) {
   const auto& method_name = shim_lifecycle.method_name();
   auto receiver_register = shim_lifecycle.receiver_register(instruction);
 
@@ -483,7 +484,7 @@ void process_shim_lifecycle(
         caller->show());
     return;
   } else if (
-      target_lifecycle_methods.size() >= Heuristics::kJoinOverrideThreshold) {
+      target_lifecycle_methods.size() >= heuristics.k_join_override_threshold()) {
     // Although this is not a join, shimming to the derived life-cycle methods
     // simulates the joining the models of these as if they were virtual
     // overrides. Besides, if there is a large number of overrides, there will
@@ -496,7 +497,7 @@ void process_shim_lifecycle(
         target_lifecycle_methods.size(),
         show(instruction),
         caller->show(),
-        Heuristics::kJoinOverrideThreshold);
+        heuristics.k_join_override_threshold());
     return;
   }
 
@@ -527,7 +528,8 @@ std::vector<ArtificialCallee> shim_artificial_callees(
     const FeatureFactory& feature_factory,
     const Shim& shim,
     std::unordered_map<std::string, TextualOrderIndex>&
-        sink_textual_order_index) {
+        sink_textual_order_index,
+    const Heuristics& heuristics) {
   std::vector<ArtificialCallee> artificial_callees;
 
   for (const auto& shim_target : shim.targets()) {
@@ -572,7 +574,8 @@ std::vector<ArtificialCallee> shim_artificial_callees(
         class_hierarchies,
         feature_factory,
         sink_textual_order_index,
-        artificial_callees);
+        artificial_callees,
+        heuristics);
   }
 
   for (const auto& shim_target : shim.intent_routing_targets()) {
@@ -702,7 +705,8 @@ InstructionCallGraphInformation process_instruction(
         class_hierarchies,
         feature_factory,
         *shim,
-        sink_textual_order_index);
+        sink_textual_order_index,
+        options.heuristics());
   }
 
   auto call_index =

--- a/source/ClassProperties.cpp
+++ b/source/ClassProperties.cpp
@@ -109,7 +109,8 @@ ClassProperties::ClassProperties(
     const FeatureFactory& feature_factory,
     const Dependencies& dependencies,
     std::unique_ptr<AndroidResources> android_resources)
-    : feature_factory_(feature_factory), dependencies_(dependencies) {
+    : feature_factory_(feature_factory),
+      dependencies_(dependencies) {
   try {
     if (android_resources == nullptr) {
       android_resources = create_resource_reader(options.apk_directory());
@@ -227,7 +228,8 @@ bool ClassProperties::is_dfa_public(std::string_view class_name) const {
 
 FeatureMayAlwaysSet ClassProperties::issue_features(
     const Method* method,
-    std::unordered_set<const Kind*> kinds) const {
+    std::unordered_set<const Kind*> kinds,
+    const Heuristics& heuristics) const {
   FeatureSet features;
   auto clazz = method->get_class()->str();
 
@@ -246,7 +248,7 @@ FeatureMayAlwaysSet ClassProperties::issue_features(
         !kind_features.contains(
             feature_factory_.get("via-caller-unexported"))) {
       kind_features.join_with(
-          compute_transitive_class_features(method, named_kind));
+          compute_transitive_class_features(method, named_kind, heuristics));
     }
     features.join_with(kind_features);
   }
@@ -350,7 +352,8 @@ ClassProperties::get_service_from_stub(const DexClass* clazz) {
 
 FeatureSet ClassProperties::compute_transitive_class_features(
     const Method* callee,
-    const NamedKind* kind) const {
+    const NamedKind* kind,
+    const Heuristics& heuristics) const {
   // Check cache
   if (const auto* target_method = via_dependencies_.get(callee, nullptr)) {
     return get_class_features(
@@ -388,7 +391,7 @@ FeatureSet ClassProperties::compute_transitive_class_features(
       continue;
     }
 
-    if (depth == Heuristics::kMaxDepthClassProperties) {
+    if (depth == heuristics.k_max_depth_class_properties()) {
       continue;
     }
 

--- a/source/ClassProperties.cpp
+++ b/source/ClassProperties.cpp
@@ -391,7 +391,7 @@ FeatureSet ClassProperties::compute_transitive_class_features(
       continue;
     }
 
-    if (depth == heuristics.k_max_depth_class_properties()) {
+    if (depth == heuristics.max_depth_class_properties()) {
       continue;
     }
 

--- a/source/ClassProperties.h
+++ b/source/ClassProperties.h
@@ -54,13 +54,15 @@ class ClassProperties final {
       size_t dependency_depth = 0) const;
   FeatureSet compute_transitive_class_features(
       const Method* method,
-      const NamedKind* kind) const;
+      const NamedKind* kind,
+      const Heuristics& heuristics) const;
 
  public:
   /* A set of features to add on issues found in the given method. */
   FeatureMayAlwaysSet issue_features(
       const Method* method,
-      std::unordered_set<const Kind*> kinds) const;
+      std::unordered_set<const Kind*> kinds,
+      const Heuristics& heuristics) const;
 
   static DexClass* MT_NULLABLE get_service_from_stub(const DexClass* clazz);
 

--- a/source/Dependencies.cpp
+++ b/source/Dependencies.cpp
@@ -70,9 +70,9 @@ Dependencies::Dependencies(
             return;
           }
 
-          if (Heuristics::kWarnOverrideThreshold &&
+          if (options.heuristics().k_warn_override_threshold() &&
               overrides.get(call_target.resolved_base_callee()).size() >=
-                  *Heuristics::kWarnOverrideThreshold) {
+                  *(options.heuristics().k_warn_override_threshold())) {
             warn_many_overrides.insert(call_target.resolved_base_callee());
           }
 

--- a/source/Dependencies.cpp
+++ b/source/Dependencies.cpp
@@ -70,9 +70,9 @@ Dependencies::Dependencies(
             return;
           }
 
-          if (options.heuristics().k_warn_override_threshold() &&
+          if (options.heuristics().warn_override_threshold() &&
               overrides.get(call_target.resolved_base_callee()).size() >=
-                  *(options.heuristics().k_warn_override_threshold())) {
+                  *(options.heuristics().warn_override_threshold())) {
             warn_many_overrides.insert(call_target.resolved_base_callee());
           }
 

--- a/source/ForwardTaintTransfer.cpp
+++ b/source/ForwardTaintTransfer.cpp
@@ -435,7 +435,10 @@ void create_issue(
   });
 
   source.add_locally_inferred_features(
-      context->class_properties.issue_features(context->method(), kinds));
+      context->class_properties.issue_features(
+        context->method(),
+        kinds,
+        context->options.heuristics()));
 
   sink.add_locally_inferred_features(extra_features);
   auto issue = Issue(
@@ -810,7 +813,7 @@ void apply_call_effects(MethodContext* context, const CalleeModel& callee) {
 
         auto sinks_copy = sinks;
         context->new_model.add_inferred_call_effect_sinks(
-            port, std::move(sinks_copy));
+            port, std::move(sinks_copy), context->options.heuristics());
 
       } break;
       case Root::Kind::CallEffectIntent:
@@ -1243,7 +1246,8 @@ void infer_output_taint(
         std::move(generation),
         /* widening_features */
         FeatureMayAlwaysSet{
-            context->feature_factory.get_widen_broadening_feature()});
+            context->feature_factory.get_widen_broadening_feature()},
+        context->options.heuristics());
   }
 }
 

--- a/source/Heuristics.cpp
+++ b/source/Heuristics.cpp
@@ -10,45 +10,52 @@
 
 namespace marianatrench {
 
-Heuristics::Heuristics(std::size_t join_override_threshold,
-                       std::size_t android_join_override_threshold,
-                       std::optional<std::size_t> warn_override_threshold,
-                       std::size_t generation_max_port_size,
-                       std::size_t generation_max_output_path_leaves,
-                       std::size_t parameter_source_max_port_size,
-                       std::size_t parameter_source_max_output_path_leaves,
-                       std::size_t sink_max_port_size,
-                       std::size_t sink_max_input_path_leaves,
-                       std::size_t call_effect_source_max_port_size,
-                       std::size_t call_effect_source_max_output_path_leaves,
-                       std::size_t call_effect_sink_max_port_size,
-                       std::size_t call_effect_sink_max_input_path_leaves,
-                       std::size_t max_number_iterations,
-                       std::size_t max_depth_class_properties,
-                       std::size_t max_call_chain_source_sink_distance,
-                       std::size_t propagation_max_input_path_size,
-                       std::size_t propagation_max_input_path_leaves)
-    : join_override_threshold_(join_override_threshold),
-      android_join_override_threshold_(android_join_override_threshold),
-      warn_override_threshold_(warn_override_threshold),
-      generation_max_port_size_(generation_max_port_size),
-      generation_max_output_path_leaves_(generation_max_output_path_leaves),
-      parameter_source_max_port_size_(parameter_source_max_port_size),
+// Default values for heuristics parameters.
+constexpr std::size_t join_override_threshold_default = 40;
+constexpr std::size_t android_join_override_threshold_default = 10;
+constexpr std::optional<std::size_t> warn_override_threshold_default = std::nullopt;
+constexpr std::size_t generation_max_port_size_default = 4;
+constexpr std::size_t generation_max_output_path_leaves_default = 20;
+constexpr std::size_t parameter_source_max_port_size_default = 4;
+constexpr std::size_t parameter_source_max_output_path_leaves_default = 20;
+constexpr std::size_t sink_max_port_size_default = 4;
+constexpr std::size_t sink_max_input_path_leaves_default = 20;
+constexpr std::size_t call_effect_source_max_port_size_default = 4;
+constexpr std::size_t call_effect_source_max_output_path_leaves_default = 20;
+constexpr std::size_t call_effect_sink_max_port_size_default = 4;
+constexpr std::size_t call_effect_sink_max_input_path_leaves_default = 20;
+constexpr std::size_t max_number_iterations_default = 150;
+constexpr std::size_t max_depth_class_properties_default = 10;
+constexpr std::size_t max_call_chain_source_sink_distance_default = 10;
+constexpr std::size_t propagation_max_input_path_size_default = 4;
+constexpr std::size_t propagation_max_input_path_leaves_default = 4;
+
+Heuristics::Heuristics()
+    : join_override_threshold_(join_override_threshold_default),
+      android_join_override_threshold_(android_join_override_threshold_default),
+      warn_override_threshold_(warn_override_threshold_default),
+      generation_max_port_size_(generation_max_port_size_default),
+      generation_max_output_path_leaves_(
+          generation_max_output_path_leaves_default),
+      parameter_source_max_port_size_(parameter_source_max_port_size_default),
       parameter_source_max_output_path_leaves_(
-          parameter_source_max_output_path_leaves),
-      sink_max_port_size_(sink_max_port_size),
-      sink_max_input_path_leaves_(sink_max_input_path_leaves),
-      call_effect_source_max_port_size_(call_effect_source_max_port_size),
+          parameter_source_max_output_path_leaves_default),
+      sink_max_port_size_(sink_max_port_size_default),
+      sink_max_input_path_leaves_(sink_max_input_path_leaves_default),
+      call_effect_source_max_port_size_(
+          call_effect_source_max_port_size_default),
       call_effect_source_max_output_path_leaves_(
-          call_effect_source_max_output_path_leaves),
-      call_effect_sink_max_port_size_(call_effect_sink_max_port_size),
+          call_effect_source_max_output_path_leaves_default),
+      call_effect_sink_max_port_size_(call_effect_sink_max_port_size_default),
       call_effect_sink_max_input_path_leaves_(
-          call_effect_sink_max_input_path_leaves),
-      max_number_iterations_(max_number_iterations),
-      max_depth_class_properties_(max_depth_class_properties),
-      max_call_chain_source_sink_distance_(max_call_chain_source_sink_distance),
-      propagation_max_input_path_size_(propagation_max_input_path_size),
-      propagation_max_input_path_leaves_(propagation_max_input_path_leaves) {}
+          call_effect_sink_max_input_path_leaves_default),
+      max_number_iterations_(max_number_iterations_default),
+      max_depth_class_properties_(max_depth_class_properties_default),
+      max_call_chain_source_sink_distance_(
+          max_call_chain_source_sink_distance_default),
+      propagation_max_input_path_size_(propagation_max_input_path_size_default),
+      propagation_max_input_path_leaves_(
+          propagation_max_input_path_leaves_default) {}
 
 Heuristics Heuristics::from_json(const Json::Value &value) {
   // Create an `Heuristics` object with the default values.

--- a/source/Heuristics.cpp
+++ b/source/Heuristics.cpp
@@ -74,114 +74,114 @@ Heuristics Heuristics::from_json(const Json::Value &value) {
   // Set the heuristics parameters that are specified in the JSON document.
 
   if (JsonValidation::has_field(value, "join_override_threshold")) {
-    heuristics.set_join_override_threshold(
-        JsonValidation::unsigned_integer(value, "join_override_threshold"));
+    heuristics.join_override_threshold_ =
+        JsonValidation::unsigned_integer(value, "join_override_threshold");
   }
 
   if (JsonValidation::has_field(value, "android_join_override_threshold")) {
-    heuristics.set_android_join_override_threshold(
+    heuristics.android_join_override_threshold_ =
         JsonValidation::unsigned_integer(value,
-                                         "android_join_override_threshold"));
+                                         "android_join_override_threshold");
   }
 
   if (JsonValidation::has_field(value, "warn_override_threshold")) {
-    heuristics.set_warn_override_threshold(
-        JsonValidation::unsigned_integer(value, "warn_override_threshold"));
+    heuristics.warn_override_threshold_ =
+        JsonValidation::unsigned_integer(value, "warn_override_threshold");
   }
 
   if (JsonValidation::has_field(value, "generation_max_port_size")) {
-    heuristics.set_generation_max_port_size(
-        JsonValidation::unsigned_integer(value, "generation_max_port_size"));
+    heuristics.generation_max_port_size_ =
+        JsonValidation::unsigned_integer(value, "generation_max_port_size");
   }
 
   if (JsonValidation::has_field(value,
                                 "generation_max_output_path_leaves")) {
-    heuristics.set_generation_max_output_path_leaves(
+    heuristics.generation_max_output_path_leaves_ =
         JsonValidation::unsigned_integer(
-            value, "generation_max_output_path_leaves"));
+            value, "generation_max_output_path_leaves");
   }
 
   if (JsonValidation::has_field(value,
                                 "parameter_source_max_port_size")) {
-    heuristics.set_parameter_source_max_port_size(
+    heuristics.parameter_source_max_port_size_ =
         JsonValidation::unsigned_integer(
-            value, "parameter_source_max_port_size"));
+            value, "parameter_source_max_port_size");
   }
 
   if (JsonValidation::has_field(
           value, "parameter_source_max_output_path_leaves")) {
-    heuristics.set_parameter_source_max_output_path_leaves(
+    heuristics.parameter_source_max_output_path_leaves_ =
         JsonValidation::unsigned_integer(
-            value, "parameter_source_max_output_path_leaves"));
+            value, "parameter_source_max_output_path_leaves");
   }
 
   if (JsonValidation::has_field(value, "sink_max_port_size")) {
-    heuristics.set_sink_max_port_size(
-        JsonValidation::unsigned_integer(value, "sink_max_port_size"));
+    heuristics.sink_max_port_size_ =
+        JsonValidation::unsigned_integer(value, "sink_max_port_size");
   }
 
   if (JsonValidation::has_field(value, "sink_max_input_path_leaves")) {
-    heuristics.set_sink_max_input_path_leaves(JsonValidation::unsigned_integer(
-        value, "sink_max_input_path_leaves"));
+    heuristics.sink_max_input_path_leaves_ = JsonValidation::unsigned_integer(
+        value, "sink_max_input_path_leaves");
   }
 
   if (JsonValidation::has_field(value,
                                 "call_effect_source_max_port_size")) {
-    heuristics.set_call_effect_source_max_port_size(
+    heuristics.call_effect_source_max_port_size_ =
         JsonValidation::unsigned_integer(
-            value, "call_effect_source_max_port_size"));
+            value, "call_effect_source_max_port_size");
   }
 
   if (JsonValidation::has_field(
           value, "call_effect_source_max_output_path_leaves")) {
-    heuristics.set_call_effect_source_max_output_path_leaves(
+    heuristics.call_effect_source_max_output_path_leaves_ =
         JsonValidation::unsigned_integer(
-            value, "call_effect_source_max_output_path_leaves"));
+            value, "call_effect_source_max_output_path_leaves");
   }
 
   if (JsonValidation::has_field(value,
                                 "call_effect_sink_max_port_size")) {
-    heuristics.set_call_effect_sink_max_port_size(
+    heuristics.call_effect_sink_max_port_size_ =
         JsonValidation::unsigned_integer(
-            value, "call_effect_sink_max_port_size"));
+            value, "call_effect_sink_max_port_size");
   }
 
   if (JsonValidation::has_field(
           value, "call_effect_sink_max_input_path_leaves")) {
-    heuristics.set_call_effect_sink_max_input_path_leaves(
+    heuristics.call_effect_sink_max_input_path_leaves_ =
         JsonValidation::unsigned_integer(
-            value, "call_effect_sink_max_input_path_leaves"));
+            value, "call_effect_sink_max_input_path_leaves");
   }
 
   if (JsonValidation::has_field(value, "max_number_iterations")) {
-    heuristics.set_max_number_iterations(JsonValidation::unsigned_integer(
-        value, "max_number_iterations"));
+    heuristics.max_number_iterations_ = JsonValidation::unsigned_integer(
+        value, "max_number_iterations");
   }
 
   if (JsonValidation::has_field(value, "max_depth_class_properties")) {
-    heuristics.set_max_depth_class_properties(JsonValidation::unsigned_integer(
-        value, "max_depth_class_properties"));
+    heuristics.max_depth_class_properties_ = JsonValidation::unsigned_integer(
+        value, "max_depth_class_properties");
   }
 
   if (JsonValidation::has_field(
           value, "max_call_chain_source_sink_distance")) {
-    heuristics.set_max_call_chain_source_sink_distance(
+    heuristics.max_call_chain_source_sink_distance_ =
         JsonValidation::unsigned_integer(
-            value, "max_call_chain_source_sink_distance"));
+            value, "max_call_chain_source_sink_distance");
   }
 
   if (JsonValidation::has_field(value,
                                 "propagation_max_input_path_size")) {
-    heuristics.set_propagation_max_input_path_size(
+    heuristics.propagation_max_input_path_size_ =
         JsonValidation::unsigned_integer(
-            value, "propagation_max_input_path_size"));
+            value, "propagation_max_input_path_size");
   }
 
   if (JsonValidation::has_field(value,
                                 "propagation_max_input_path_leaves")) {
-    heuristics.set_propagation_max_input_path_leaves(
+    heuristics.propagation_max_input_path_leaves_ =
         JsonValidation::unsigned_integer(
-            value, "propagation_max_input_path_leaves"));
+            value, "propagation_max_input_path_leaves");
   }
 
   return heuristics;
@@ -191,164 +191,72 @@ std::size_t Heuristics::join_override_threshold() const {
   return this->join_override_threshold_;
 }
 
-void Heuristics::set_join_override_threshold(
-    std::size_t join_override_threshold) {
-  this->join_override_threshold_ = join_override_threshold;
-}
-
 std::size_t Heuristics::android_join_override_threshold() const {
   return this->android_join_override_threshold_;
-}
-
-void Heuristics::set_android_join_override_threshold(
-    std::size_t android_join_override_threshold) {
-  this->android_join_override_threshold_ = android_join_override_threshold;
 }
 
 const std::optional<std::size_t> Heuristics::warn_override_threshold() const {
   return this->warn_override_threshold_;
 }
 
-void Heuristics::set_warn_override_threshold(
-    std::size_t warn_override_threshold) {
-  this->warn_override_threshold_ = warn_override_threshold;
-}
-
 std::size_t Heuristics::generation_max_port_size() const {
   return this->generation_max_port_size_;
-}
-
-void Heuristics::set_generation_max_port_size(
-    std::size_t generation_max_port_size) {
-  this->generation_max_port_size_ = generation_max_port_size;
 }
 
 std::size_t Heuristics::generation_max_output_path_leaves() const {
   return this->generation_max_output_path_leaves_;
 }
 
-void Heuristics::set_generation_max_output_path_leaves(
-    std::size_t generation_max_output_path_leaves) {
-  this->generation_max_output_path_leaves_ = generation_max_output_path_leaves;
-}
-
 std::size_t Heuristics::parameter_source_max_port_size() const {
   return this->parameter_source_max_port_size_;
-}
-
-void Heuristics::set_parameter_source_max_port_size(
-    std::size_t parameter_source_max_port_size) {
-  this->parameter_source_max_port_size_ = parameter_source_max_port_size;
 }
 
 std::size_t Heuristics::parameter_source_max_output_path_leaves() const {
   return this->parameter_source_max_output_path_leaves_;
 }
 
-void Heuristics::set_parameter_source_max_output_path_leaves(
-    std::size_t parameter_source_max_output_path_leaves) {
-  this->parameter_source_max_output_path_leaves_ =
-      parameter_source_max_output_path_leaves;
-}
-
 std::size_t Heuristics::sink_max_port_size() const {
   return this->sink_max_port_size_;
-}
-
-void Heuristics::set_sink_max_port_size(std::size_t sink_max_port_size) {
-  this->sink_max_port_size_ = sink_max_port_size;
 }
 
 std::size_t Heuristics::sink_max_input_path_leaves() const {
   return this->sink_max_input_path_leaves_;
 }
 
-void Heuristics::set_sink_max_input_path_leaves(
-    std::size_t sink_max_input_path_leaves) {
-  this->sink_max_input_path_leaves_ = sink_max_input_path_leaves;
-}
-
 std::size_t Heuristics::call_effect_source_max_port_size() const {
   return this->call_effect_source_max_port_size_;
-}
-
-void Heuristics::set_call_effect_source_max_port_size(
-    std::size_t call_effect_source_max_port_size) {
-  this->call_effect_source_max_port_size_ = call_effect_source_max_port_size;
 }
 
 std::size_t Heuristics::call_effect_source_max_output_path_leaves() const {
   return this->call_effect_source_max_output_path_leaves_;
 }
 
-void Heuristics::set_call_effect_source_max_output_path_leaves(
-    std::size_t call_effect_source_max_output_path_leaves) {
-  this->call_effect_source_max_output_path_leaves_ =
-      call_effect_source_max_output_path_leaves;
-}
-
 std::size_t Heuristics::call_effect_sink_max_port_size() const {
   return this->call_effect_sink_max_port_size_;
-}
-
-void Heuristics::set_call_effect_sink_max_port_size(
-    std::size_t call_effect_sink_max_port_size) {
-  this->call_effect_sink_max_port_size_ = call_effect_sink_max_port_size;
 }
 
 std::size_t Heuristics::call_effect_sink_max_input_path_leaves() const {
   return this->call_effect_sink_max_input_path_leaves_;
 }
 
-void Heuristics::set_call_effect_sink_max_input_path_leaves(
-    std::size_t call_effect_sink_max_input_path_leaves) {
-  this->call_effect_sink_max_input_path_leaves_ =
-      call_effect_sink_max_input_path_leaves;
-}
-
 std::size_t Heuristics::max_number_iterations() const {
   return this->max_number_iterations_;
-}
-
-void Heuristics::set_max_number_iterations(std::size_t max_number_iterations) {
-  this->max_number_iterations_ = max_number_iterations;
 }
 
 std::size_t Heuristics::max_depth_class_properties() const {
   return this->max_depth_class_properties_;
 }
 
-void Heuristics::set_max_depth_class_properties(
-    std::size_t max_depth_class_properties) {
-  this->max_depth_class_properties_ = max_depth_class_properties;
-}
-
 std::size_t Heuristics::max_call_chain_source_sink_distance() const {
   return this->max_call_chain_source_sink_distance_;
-}
-
-void Heuristics::set_max_call_chain_source_sink_distance(
-    std::size_t max_call_chain_source_sink_distance) {
-  this->max_call_chain_source_sink_distance_ =
-      max_call_chain_source_sink_distance;
 }
 
 std::size_t Heuristics::propagation_max_input_path_size() const {
   return this->propagation_max_input_path_size_;
 }
 
-void Heuristics::set_propagation_max_input_path_size(
-    std::size_t propagation_max_input_path_size) {
-  this->propagation_max_input_path_size_ = propagation_max_input_path_size;
-}
-
 std::size_t Heuristics::propagation_max_input_path_leaves() const {
   return this->propagation_max_input_path_leaves_;
-}
-
-void Heuristics::set_propagation_max_input_path_leaves(
-    std::size_t propagation_max_input_path_leaves) {
-  this->propagation_max_input_path_leaves_ = propagation_max_input_path_leaves;
 }
 
 } // namespace marianatrench

--- a/source/Heuristics.cpp
+++ b/source/Heuristics.cpp
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <mariana-trench/Heuristics.h>
+#include <mariana-trench/JsonValidation.h>
+
+namespace marianatrench {
+
+// Names of the heuristics parameters that can be set
+inline static const std::string k_join_override_threshold_attribute =
+    "k_join_override_threshold";
+inline static const std::string k_android_join_override_threshold_attribute =
+    "k_android_join_override_threshold";
+inline static const std::string k_warn_override_threshold_attribute =
+    "k_warn_override_threshold";
+inline static const std::string k_generation_max_port_size_attribute =
+    "k_generation_max_port_size";
+static inline const std::string k_generation_max_output_path_leaves_attribute =
+    "k_generation_max_output_path_leaves";
+static inline const std::string k_parameter_source_max_port_size_attribute =
+    "k_parameter_source_max_port_size";
+static inline const std::string k_parameter_source_max_output_path_leaves_attribute =
+    "k_parameter_source_max_output_path_leaves";
+static inline const std::string k_sink_max_port_size_attribute =
+    "k_sink_max_port_size";
+static inline const std::string k_sink_max_input_path_leaves_attribute =
+    "k_sink_max_input_path_leaves";
+static inline const std::string k_call_effect_source_max_port_size_attribute =
+    "k_call_effect_source_max_port_size";
+static inline const std::string
+    k_call_effect_source_max_output_path_leaves_attribute =
+        "k_call_effect_source_max_output_path_leaves";
+static inline const std::string k_call_effect_sink_max_port_size_attribute =
+    "k_call_effect_sink_max_port_size";
+static inline const std::string k_call_effect_sink_max_input_path_leaves_attribute =
+    "k_call_effect_sink_max_input_path_leaves";
+static inline const std::string k_max_number_iterations_attribute =
+    "k_max_number_iterations";
+static inline const std::string k_max_depth_class_properties_attribute =
+    "k_max_depth_class_properties";
+static inline const std::string k_max_call_chain_source_sink_distance_attribute =
+    "k_max_call_chain_source_sink_distance";
+static inline const std::string k_propagation_max_input_path_size_attribute =
+    "k_propagation_max_input_path_size";
+static inline const std::string k_propagation_max_input_path_leaves_attribute =
+    "k_propagation_max_input_path_leaves";
+
+Heuristics::Heuristics(std::size_t k_join_override_threshold,
+                       std::size_t k_android_join_override_threshold,
+                       std::optional<std::size_t> k_warn_override_threshold,
+                       std::size_t k_generation_max_port_size,
+                       std::size_t k_generation_max_output_path_leaves,
+                       std::size_t k_parameter_source_max_port_size,
+                       std::size_t k_parameter_source_max_output_path_leaves,
+                       std::size_t k_sink_max_port_size,
+                       std::size_t k_sink_max_input_path_leaves,
+                       std::size_t k_call_effect_source_max_port_size,
+                       std::size_t k_call_effect_source_max_output_path_leaves,
+                       std::size_t k_call_effect_sink_max_port_size,
+                       std::size_t k_call_effect_sink_max_input_path_leaves,
+                       std::size_t k_max_number_iterations,
+                       std::size_t k_max_depth_class_properties,
+                       std::size_t k_max_call_chain_source_sink_distance,
+                       std::size_t k_propagation_max_input_path_size,
+                       std::size_t k_propagation_max_input_path_leaves)
+    : k_join_override_threshold_(k_join_override_threshold),
+      k_android_join_override_threshold_(k_android_join_override_threshold),
+      k_warn_override_threshold_(k_warn_override_threshold),
+      k_generation_max_port_size_(k_generation_max_port_size),
+      k_generation_max_output_path_leaves_(k_generation_max_output_path_leaves),
+      k_parameter_source_max_port_size_(k_parameter_source_max_port_size),
+      k_parameter_source_max_output_path_leaves_(
+          k_parameter_source_max_output_path_leaves),
+      k_sink_max_port_size_(k_sink_max_port_size),
+      k_sink_max_input_path_leaves_(k_sink_max_input_path_leaves),
+      k_call_effect_source_max_port_size_(k_call_effect_source_max_port_size),
+      k_call_effect_source_max_output_path_leaves_(
+          k_call_effect_source_max_output_path_leaves),
+      k_call_effect_sink_max_port_size_(k_call_effect_sink_max_port_size),
+      k_call_effect_sink_max_input_path_leaves_(
+          k_call_effect_sink_max_input_path_leaves),
+      k_max_number_iterations_(k_max_number_iterations),
+      k_max_depth_class_properties_(k_max_depth_class_properties),
+      k_max_call_chain_source_sink_distance_(
+          k_max_call_chain_source_sink_distance),
+      k_propagation_max_input_path_size_(k_propagation_max_input_path_size),
+      k_propagation_max_input_path_leaves_(
+          k_propagation_max_input_path_leaves) {}
+
+Heuristics Heuristics::from_json(const Json::Value &value) {
+  // Create an `Heuristics` object with the default values.
+  Heuristics heuristics = Heuristics();
+  JsonValidation::validate_object(value);
+  JsonValidation::check_unexpected_members(
+      value,
+      {k_join_override_threshold_attribute,
+       k_android_join_override_threshold_attribute,
+       k_warn_override_threshold_attribute,
+       k_generation_max_port_size_attribute,
+       k_generation_max_output_path_leaves_attribute,
+       k_parameter_source_max_port_size_attribute,
+       k_parameter_source_max_output_path_leaves_attribute,
+       k_sink_max_port_size_attribute, k_sink_max_input_path_leaves_attribute,
+       k_call_effect_source_max_port_size_attribute,
+       k_call_effect_source_max_output_path_leaves_attribute,
+       k_call_effect_sink_max_port_size_attribute,
+       k_call_effect_sink_max_input_path_leaves_attribute,
+       k_max_number_iterations_attribute,
+       k_max_depth_class_properties_attribute,
+       k_max_call_chain_source_sink_distance_attribute,
+       k_propagation_max_input_path_size_attribute,
+       k_propagation_max_input_path_leaves_attribute});
+
+  // Set the heuristics parameters that are specified in the JSON document.
+
+  if (JsonValidation::has_field(value, k_join_override_threshold_attribute)) {
+    heuristics.set_k_join_override_threshold(JsonValidation::unsigned_integer(
+        value, k_join_override_threshold_attribute));
+  }
+
+  if (JsonValidation::has_field(value,
+                                k_android_join_override_threshold_attribute)) {
+    heuristics.set_k_android_join_override_threshold(
+        JsonValidation::unsigned_integer(
+            value, k_android_join_override_threshold_attribute));
+  }
+
+  if (JsonValidation::has_field(value, k_warn_override_threshold_attribute)) {
+    heuristics.set_k_warn_override_threshold(JsonValidation::unsigned_integer(
+        value, k_warn_override_threshold_attribute));
+  }
+
+  if (JsonValidation::has_field(value, k_generation_max_port_size_attribute)) {
+    heuristics.set_k_generation_max_port_size(JsonValidation::unsigned_integer(
+        value, k_generation_max_port_size_attribute));
+  }
+
+  if (JsonValidation::has_field(
+          value, k_generation_max_output_path_leaves_attribute)) {
+    heuristics.set_k_generation_max_output_path_leaves(
+        JsonValidation::unsigned_integer(
+            value, k_generation_max_output_path_leaves_attribute));
+  }
+
+  if (JsonValidation::has_field(value,
+                                k_parameter_source_max_port_size_attribute)) {
+    heuristics.set_k_parameter_source_max_port_size(
+        JsonValidation::unsigned_integer(
+            value, k_parameter_source_max_port_size_attribute));
+  }
+
+  if (JsonValidation::has_field(
+          value, k_parameter_source_max_output_path_leaves_attribute)) {
+    heuristics.set_k_parameter_source_max_output_path_leaves(
+        JsonValidation::unsigned_integer(
+            value, k_parameter_source_max_output_path_leaves_attribute));
+  }
+
+  if (JsonValidation::has_field(value, k_sink_max_port_size_attribute)) {
+    heuristics.set_k_sink_max_port_size(JsonValidation::unsigned_integer(
+        value, k_sink_max_port_size_attribute));
+  }
+
+  if (JsonValidation::has_field(value,
+                                k_sink_max_input_path_leaves_attribute)) {
+    heuristics.set_k_sink_max_input_path_leaves(
+        JsonValidation::unsigned_integer(
+            value, k_sink_max_input_path_leaves_attribute));
+  }
+
+  if (JsonValidation::has_field(value,
+                                k_call_effect_source_max_port_size_attribute)) {
+    heuristics.set_k_call_effect_source_max_port_size(
+        JsonValidation::unsigned_integer(
+            value, k_call_effect_source_max_port_size_attribute));
+  }
+
+  if (JsonValidation::has_field(
+          value, k_call_effect_source_max_output_path_leaves_attribute)) {
+    heuristics.set_k_call_effect_source_max_output_path_leaves(
+        JsonValidation::unsigned_integer(
+            value, k_call_effect_source_max_output_path_leaves_attribute));
+  }
+
+  if (JsonValidation::has_field(value,
+                                k_call_effect_sink_max_port_size_attribute)) {
+    heuristics.set_k_call_effect_sink_max_port_size(
+        JsonValidation::unsigned_integer(
+            value, k_call_effect_sink_max_port_size_attribute));
+  }
+
+  if (JsonValidation::has_field(
+          value, k_call_effect_sink_max_input_path_leaves_attribute)) {
+    heuristics.set_k_call_effect_sink_max_input_path_leaves(
+        JsonValidation::unsigned_integer(
+            value, k_call_effect_sink_max_input_path_leaves_attribute));
+  }
+
+  if (JsonValidation::has_field(value, k_max_number_iterations_attribute)) {
+    heuristics.set_k_max_number_iterations(JsonValidation::unsigned_integer(
+        value, k_max_number_iterations_attribute));
+  }
+
+  if (JsonValidation::has_field(value,
+                                k_max_depth_class_properties_attribute)) {
+    heuristics.set_k_max_depth_class_properties(
+        JsonValidation::unsigned_integer(
+            value, k_max_depth_class_properties_attribute));
+  }
+
+  if (JsonValidation::has_field(
+          value, k_max_call_chain_source_sink_distance_attribute)) {
+    heuristics.set_k_max_call_chain_source_sink_distance(
+        JsonValidation::unsigned_integer(
+            value, k_max_call_chain_source_sink_distance_attribute));
+  }
+
+  if (JsonValidation::has_field(value,
+                                k_propagation_max_input_path_size_attribute)) {
+    heuristics.set_k_propagation_max_input_path_size(
+        JsonValidation::unsigned_integer(
+            value, k_propagation_max_input_path_size_attribute));
+  }
+
+  if (JsonValidation::has_field(
+          value, k_propagation_max_input_path_leaves_attribute)) {
+    heuristics.set_k_propagation_max_input_path_leaves(
+        JsonValidation::unsigned_integer(
+            value, k_propagation_max_input_path_leaves_attribute));
+  }
+
+  return heuristics;
+}
+
+std::size_t Heuristics::k_join_override_threshold() const {
+  return this->k_join_override_threshold_;
+}
+
+void Heuristics::set_k_join_override_threshold(
+    std::size_t k_join_override_threshold) {
+  this->k_join_override_threshold_ = k_join_override_threshold;
+}
+
+std::size_t Heuristics::k_android_join_override_threshold() const {
+  return this->k_android_join_override_threshold_;
+}
+
+void Heuristics::set_k_android_join_override_threshold(
+    std::size_t k_android_join_override_threshold) {
+  this->k_android_join_override_threshold_ = k_android_join_override_threshold;
+}
+
+const std::optional<std::size_t> Heuristics::k_warn_override_threshold() const {
+  return this->k_warn_override_threshold_;
+}
+
+void Heuristics::set_k_warn_override_threshold(
+    std::size_t k_warn_override_threshold) {
+  this->k_warn_override_threshold_ = k_warn_override_threshold;
+}
+
+std::size_t Heuristics::k_generation_max_port_size() const {
+  return this->k_generation_max_port_size_;
+}
+
+void Heuristics::set_k_generation_max_port_size(
+    std::size_t k_generation_max_port_size) {
+  this->k_generation_max_port_size_ = k_generation_max_port_size;
+}
+
+std::size_t Heuristics::k_generation_max_output_path_leaves() const {
+  return this->k_generation_max_output_path_leaves_;
+}
+
+void Heuristics::set_k_generation_max_output_path_leaves(
+    std::size_t k_generation_max_output_path_leaves) {
+  this->k_generation_max_output_path_leaves_ =
+      k_generation_max_output_path_leaves;
+}
+
+std::size_t Heuristics::k_parameter_source_max_port_size() const {
+  return this->k_parameter_source_max_port_size_;
+}
+
+void Heuristics::set_k_parameter_source_max_port_size(
+    std::size_t k_parameter_source_max_port_size) {
+  this->k_parameter_source_max_port_size_ = k_parameter_source_max_port_size;
+}
+
+std::size_t Heuristics::k_parameter_source_max_output_path_leaves() const {
+  return this->k_parameter_source_max_output_path_leaves_;
+}
+
+void Heuristics::set_k_parameter_source_max_output_path_leaves(
+    std::size_t k_parameter_source_max_output_path_leaves) {
+  this->k_parameter_source_max_output_path_leaves_ =
+      k_parameter_source_max_output_path_leaves;
+}
+
+std::size_t Heuristics::k_sink_max_port_size() const {
+  return this->k_sink_max_port_size_;
+}
+
+void Heuristics::set_k_sink_max_port_size(std::size_t k_sink_max_port_size) {
+  this->k_sink_max_port_size_ = k_sink_max_port_size;
+}
+
+std::size_t Heuristics::k_sink_max_input_path_leaves() const {
+  return this->k_sink_max_input_path_leaves_;
+}
+
+void Heuristics::set_k_sink_max_input_path_leaves(
+    std::size_t k_sink_max_input_path_leaves) {
+  this->k_sink_max_input_path_leaves_ = k_sink_max_input_path_leaves;
+}
+
+std::size_t Heuristics::k_call_effect_source_max_port_size() const {
+  return this->k_call_effect_source_max_port_size_;
+}
+
+void Heuristics::set_k_call_effect_source_max_port_size(
+    std::size_t k_call_effect_source_max_port_size) {
+  this->k_call_effect_source_max_port_size_ =
+      k_call_effect_source_max_port_size;
+}
+
+std::size_t Heuristics::k_call_effect_source_max_output_path_leaves() const {
+  return this->k_call_effect_source_max_output_path_leaves_;
+}
+
+void Heuristics::set_k_call_effect_source_max_output_path_leaves(
+    std::size_t k_call_effect_source_max_output_path_leaves) {
+  this->k_call_effect_source_max_output_path_leaves_ =
+      k_call_effect_source_max_output_path_leaves;
+}
+
+std::size_t Heuristics::k_call_effect_sink_max_port_size() const {
+  return this->k_call_effect_sink_max_port_size_;
+}
+
+void Heuristics::set_k_call_effect_sink_max_port_size(
+    std::size_t k_call_effect_sink_max_port_size) {
+  this->k_call_effect_sink_max_port_size_ = k_call_effect_sink_max_port_size;
+}
+
+std::size_t Heuristics::k_call_effect_sink_max_input_path_leaves() const {
+  return this->k_call_effect_sink_max_input_path_leaves_;
+}
+
+void Heuristics::set_k_call_effect_sink_max_input_path_leaves(
+    std::size_t k_call_effect_sink_max_input_path_leaves) {
+  this->k_call_effect_sink_max_input_path_leaves_ =
+      k_call_effect_sink_max_input_path_leaves;
+}
+
+std::size_t Heuristics::k_max_number_iterations() const {
+  return this->k_max_number_iterations_;
+}
+
+void Heuristics::set_k_max_number_iterations(
+    std::size_t k_max_number_iterations) {
+  this->k_max_number_iterations_ = k_max_number_iterations;
+}
+
+std::size_t Heuristics::k_max_depth_class_properties() const {
+  return this->k_max_depth_class_properties_;
+}
+
+void Heuristics::set_k_max_depth_class_properties(
+    std::size_t k_max_depth_class_properties) {
+  this->k_max_depth_class_properties_ = k_max_depth_class_properties;
+}
+
+std::size_t Heuristics::k_max_call_chain_source_sink_distance() const {
+  return this->k_max_call_chain_source_sink_distance_;
+}
+
+void Heuristics::set_k_max_call_chain_source_sink_distance(
+    std::size_t k_max_call_chain_source_sink_distance) {
+  this->k_max_call_chain_source_sink_distance_ =
+      k_max_call_chain_source_sink_distance;
+}
+
+std::size_t Heuristics::k_propagation_max_input_path_size() const {
+  return this->k_propagation_max_input_path_size_;
+}
+
+void Heuristics::set_k_propagation_max_input_path_size(
+    std::size_t k_propagation_max_input_path_size) {
+  this->k_propagation_max_input_path_size_ = k_propagation_max_input_path_size;
+}
+
+std::size_t Heuristics::k_propagation_max_input_path_leaves() const {
+  return this->k_propagation_max_input_path_leaves_;
+}
+
+void Heuristics::set_k_propagation_max_input_path_leaves(
+    std::size_t k_propagation_max_input_path_leaves) {
+  this->k_propagation_max_input_path_leaves_ =
+      k_propagation_max_input_path_leaves;
+}
+
+} // namespace marianatrench

--- a/source/Heuristics.cpp
+++ b/source/Heuristics.cpp
@@ -5,53 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#pragma once
-
 #include <mariana-trench/Heuristics.h>
 #include <mariana-trench/JsonValidation.h>
 
 namespace marianatrench {
-
-// Names of the heuristics parameters that can be set
-inline static const std::string join_override_threshold_attribute =
-    "join_override_threshold";
-inline static const std::string android_join_override_threshold_attribute =
-    "android_join_override_threshold";
-inline static const std::string warn_override_threshold_attribute =
-    "warn_override_threshold";
-inline static const std::string generation_max_port_size_attribute =
-    "generation_max_port_size";
-static inline const std::string generation_max_output_path_leaves_attribute =
-    "generation_max_output_path_leaves";
-static inline const std::string parameter_source_max_port_size_attribute =
-    "parameter_source_max_port_size";
-static inline const std::string
-    parameter_source_max_output_path_leaves_attribute =
-        "parameter_source_max_output_path_leaves";
-static inline const std::string sink_max_port_size_attribute =
-    "sink_max_port_size";
-static inline const std::string sink_max_input_path_leaves_attribute =
-    "sink_max_input_path_leaves";
-static inline const std::string call_effect_source_max_port_size_attribute =
-    "call_effect_source_max_port_size";
-static inline const std::string
-    call_effect_source_max_output_path_leaves_attribute =
-        "call_effect_source_max_output_path_leaves";
-static inline const std::string call_effect_sink_max_port_size_attribute =
-    "call_effect_sink_max_port_size";
-static inline const std::string
-    call_effect_sink_max_input_path_leaves_attribute =
-        "call_effect_sink_max_input_path_leaves";
-static inline const std::string max_number_iterations_attribute =
-    "max_number_iterations";
-static inline const std::string max_depth_class_properties_attribute =
-    "max_depth_class_properties";
-static inline const std::string max_call_chain_source_sink_distance_attribute =
-    "max_call_chain_source_sink_distance";
-static inline const std::string propagation_max_input_path_size_attribute =
-    "propagation_max_input_path_size";
-static inline const std::string propagation_max_input_path_leaves_attribute =
-    "propagation_max_input_path_leaves";
 
 Heuristics::Heuristics(std::size_t join_override_threshold,
                        std::size_t android_join_override_threshold,
@@ -99,134 +56,132 @@ Heuristics Heuristics::from_json(const Json::Value &value) {
   JsonValidation::validate_object(value);
   JsonValidation::check_unexpected_members(
       value,
-      {join_override_threshold_attribute,
-       android_join_override_threshold_attribute,
-       warn_override_threshold_attribute, generation_max_port_size_attribute,
-       generation_max_output_path_leaves_attribute,
-       parameter_source_max_port_size_attribute,
-       parameter_source_max_output_path_leaves_attribute,
-       sink_max_port_size_attribute, sink_max_input_path_leaves_attribute,
-       call_effect_source_max_port_size_attribute,
-       call_effect_source_max_output_path_leaves_attribute,
-       call_effect_sink_max_port_size_attribute,
-       call_effect_sink_max_input_path_leaves_attribute,
-       max_number_iterations_attribute, max_depth_class_properties_attribute,
-       max_call_chain_source_sink_distance_attribute,
-       propagation_max_input_path_size_attribute,
-       propagation_max_input_path_leaves_attribute});
+      {"join_override_threshold", "android_join_override_threshold",
+       "warn_override_threshold", "generation_max_port_size",
+       "generation_max_output_path_leaves",
+       "parameter_source_max_port_size",
+       "parameter_source_max_output_path_leaves",
+       "sink_max_port_size", "sink_max_input_path_leaves",
+       "call_effect_source_max_port_size",
+       "call_effect_source_max_output_path_leaves",
+       "call_effect_sink_max_port_size",
+       "call_effect_sink_max_input_path_leaves",
+       "max_number_iterations", "max_depth_class_properties",
+       "max_call_chain_source_sink_distance",
+       "propagation_max_input_path_size",
+       "propagation_max_input_path_leaves"});
 
   // Set the heuristics parameters that are specified in the JSON document.
 
-  if (JsonValidation::has_field(value, join_override_threshold_attribute)) {
-    heuristics.set_join_override_threshold(JsonValidation::unsigned_integer(
-        value, join_override_threshold_attribute));
+  if (JsonValidation::has_field(value, "join_override_threshold")) {
+    heuristics.set_join_override_threshold(
+        JsonValidation::unsigned_integer(value, "join_override_threshold"));
   }
 
-  if (JsonValidation::has_field(value,
-                                android_join_override_threshold_attribute)) {
+  if (JsonValidation::has_field(value, "android_join_override_threshold")) {
     heuristics.set_android_join_override_threshold(
-        JsonValidation::unsigned_integer(
-            value, android_join_override_threshold_attribute));
+        JsonValidation::unsigned_integer(value,
+                                         "android_join_override_threshold"));
   }
 
-  if (JsonValidation::has_field(value, warn_override_threshold_attribute)) {
-    heuristics.set_warn_override_threshold(JsonValidation::unsigned_integer(
-        value, warn_override_threshold_attribute));
+  if (JsonValidation::has_field(value, "warn_override_threshold")) {
+    heuristics.set_warn_override_threshold(
+        JsonValidation::unsigned_integer(value, "warn_override_threshold"));
   }
 
-  if (JsonValidation::has_field(value, generation_max_port_size_attribute)) {
-    heuristics.set_generation_max_port_size(JsonValidation::unsigned_integer(
-        value, generation_max_port_size_attribute));
+  if (JsonValidation::has_field(value, "generation_max_port_size")) {
+    heuristics.set_generation_max_port_size(
+        JsonValidation::unsigned_integer(value, "generation_max_port_size"));
   }
 
   if (JsonValidation::has_field(value,
-                                generation_max_output_path_leaves_attribute)) {
+                                "generation_max_output_path_leaves")) {
     heuristics.set_generation_max_output_path_leaves(
         JsonValidation::unsigned_integer(
-            value, generation_max_output_path_leaves_attribute));
+            value, "generation_max_output_path_leaves"));
   }
 
   if (JsonValidation::has_field(value,
-                                parameter_source_max_port_size_attribute)) {
+                                "parameter_source_max_port_size")) {
     heuristics.set_parameter_source_max_port_size(
         JsonValidation::unsigned_integer(
-            value, parameter_source_max_port_size_attribute));
+            value, "parameter_source_max_port_size"));
   }
 
   if (JsonValidation::has_field(
-          value, parameter_source_max_output_path_leaves_attribute)) {
+          value, "parameter_source_max_output_path_leaves")) {
     heuristics.set_parameter_source_max_output_path_leaves(
         JsonValidation::unsigned_integer(
-            value, parameter_source_max_output_path_leaves_attribute));
+            value, "parameter_source_max_output_path_leaves"));
   }
 
-  if (JsonValidation::has_field(value, sink_max_port_size_attribute)) {
+  if (JsonValidation::has_field(value, "sink_max_port_size")) {
     heuristics.set_sink_max_port_size(
-        JsonValidation::unsigned_integer(value, sink_max_port_size_attribute));
+        JsonValidation::unsigned_integer(value, "sink_max_port_size"));
   }
 
-  if (JsonValidation::has_field(value, sink_max_input_path_leaves_attribute)) {
+  if (JsonValidation::has_field(value, "sink_max_input_path_leaves")) {
     heuristics.set_sink_max_input_path_leaves(JsonValidation::unsigned_integer(
-        value, sink_max_input_path_leaves_attribute));
+        value, "sink_max_input_path_leaves"));
   }
 
   if (JsonValidation::has_field(value,
-                                call_effect_source_max_port_size_attribute)) {
+                                "call_effect_source_max_port_size")) {
     heuristics.set_call_effect_source_max_port_size(
         JsonValidation::unsigned_integer(
-            value, call_effect_source_max_port_size_attribute));
+            value, "call_effect_source_max_port_size"));
   }
 
   if (JsonValidation::has_field(
-          value, call_effect_source_max_output_path_leaves_attribute)) {
+          value, "call_effect_source_max_output_path_leaves")) {
     heuristics.set_call_effect_source_max_output_path_leaves(
         JsonValidation::unsigned_integer(
-            value, call_effect_source_max_output_path_leaves_attribute));
+            value, "call_effect_source_max_output_path_leaves"));
   }
 
   if (JsonValidation::has_field(value,
-                                call_effect_sink_max_port_size_attribute)) {
+                                "call_effect_sink_max_port_size")) {
     heuristics.set_call_effect_sink_max_port_size(
         JsonValidation::unsigned_integer(
-            value, call_effect_sink_max_port_size_attribute));
+            value, "call_effect_sink_max_port_size"));
   }
 
   if (JsonValidation::has_field(
-          value, call_effect_sink_max_input_path_leaves_attribute)) {
+          value, "call_effect_sink_max_input_path_leaves")) {
     heuristics.set_call_effect_sink_max_input_path_leaves(
         JsonValidation::unsigned_integer(
-            value, call_effect_sink_max_input_path_leaves_attribute));
+            value, "call_effect_sink_max_input_path_leaves"));
   }
 
-  if (JsonValidation::has_field(value, max_number_iterations_attribute)) {
+  if (JsonValidation::has_field(value, "max_number_iterations")) {
     heuristics.set_max_number_iterations(JsonValidation::unsigned_integer(
-        value, max_number_iterations_attribute));
+        value, "max_number_iterations"));
   }
 
-  if (JsonValidation::has_field(value, max_depth_class_properties_attribute)) {
+  if (JsonValidation::has_field(value, "max_depth_class_properties")) {
     heuristics.set_max_depth_class_properties(JsonValidation::unsigned_integer(
-        value, max_depth_class_properties_attribute));
+        value, "max_depth_class_properties"));
   }
 
   if (JsonValidation::has_field(
-          value, max_call_chain_source_sink_distance_attribute)) {
+          value, "max_call_chain_source_sink_distance")) {
     heuristics.set_max_call_chain_source_sink_distance(
         JsonValidation::unsigned_integer(
-            value, max_call_chain_source_sink_distance_attribute));
+            value, "max_call_chain_source_sink_distance"));
   }
 
   if (JsonValidation::has_field(value,
-                                propagation_max_input_path_size_attribute)) {
+                                "propagation_max_input_path_size")) {
     heuristics.set_propagation_max_input_path_size(
         JsonValidation::unsigned_integer(
-            value, propagation_max_input_path_size_attribute));
+            value, "propagation_max_input_path_size"));
   }
 
   if (JsonValidation::has_field(value,
-                                propagation_max_input_path_leaves_attribute)) {
+                                "propagation_max_input_path_leaves")) {
     heuristics.set_propagation_max_input_path_leaves(
         JsonValidation::unsigned_integer(
-            value, propagation_max_input_path_leaves_attribute));
+            value, "propagation_max_input_path_leaves"));
   }
 
   return heuristics;

--- a/source/Heuristics.cpp
+++ b/source/Heuristics.cpp
@@ -13,85 +13,85 @@
 namespace marianatrench {
 
 // Names of the heuristics parameters that can be set
-inline static const std::string k_join_override_threshold_attribute =
-    "k_join_override_threshold";
-inline static const std::string k_android_join_override_threshold_attribute =
-    "k_android_join_override_threshold";
-inline static const std::string k_warn_override_threshold_attribute =
-    "k_warn_override_threshold";
-inline static const std::string k_generation_max_port_size_attribute =
-    "k_generation_max_port_size";
-static inline const std::string k_generation_max_output_path_leaves_attribute =
-    "k_generation_max_output_path_leaves";
-static inline const std::string k_parameter_source_max_port_size_attribute =
-    "k_parameter_source_max_port_size";
-static inline const std::string k_parameter_source_max_output_path_leaves_attribute =
-    "k_parameter_source_max_output_path_leaves";
-static inline const std::string k_sink_max_port_size_attribute =
-    "k_sink_max_port_size";
-static inline const std::string k_sink_max_input_path_leaves_attribute =
-    "k_sink_max_input_path_leaves";
-static inline const std::string k_call_effect_source_max_port_size_attribute =
-    "k_call_effect_source_max_port_size";
+inline static const std::string join_override_threshold_attribute =
+    "join_override_threshold";
+inline static const std::string android_join_override_threshold_attribute =
+    "android_join_override_threshold";
+inline static const std::string warn_override_threshold_attribute =
+    "warn_override_threshold";
+inline static const std::string generation_max_port_size_attribute =
+    "generation_max_port_size";
+static inline const std::string generation_max_output_path_leaves_attribute =
+    "generation_max_output_path_leaves";
+static inline const std::string parameter_source_max_port_size_attribute =
+    "parameter_source_max_port_size";
 static inline const std::string
-    k_call_effect_source_max_output_path_leaves_attribute =
-        "k_call_effect_source_max_output_path_leaves";
-static inline const std::string k_call_effect_sink_max_port_size_attribute =
-    "k_call_effect_sink_max_port_size";
-static inline const std::string k_call_effect_sink_max_input_path_leaves_attribute =
-    "k_call_effect_sink_max_input_path_leaves";
-static inline const std::string k_max_number_iterations_attribute =
-    "k_max_number_iterations";
-static inline const std::string k_max_depth_class_properties_attribute =
-    "k_max_depth_class_properties";
-static inline const std::string k_max_call_chain_source_sink_distance_attribute =
-    "k_max_call_chain_source_sink_distance";
-static inline const std::string k_propagation_max_input_path_size_attribute =
-    "k_propagation_max_input_path_size";
-static inline const std::string k_propagation_max_input_path_leaves_attribute =
-    "k_propagation_max_input_path_leaves";
+    parameter_source_max_output_path_leaves_attribute =
+        "parameter_source_max_output_path_leaves";
+static inline const std::string sink_max_port_size_attribute =
+    "sink_max_port_size";
+static inline const std::string sink_max_input_path_leaves_attribute =
+    "sink_max_input_path_leaves";
+static inline const std::string call_effect_source_max_port_size_attribute =
+    "call_effect_source_max_port_size";
+static inline const std::string
+    call_effect_source_max_output_path_leaves_attribute =
+        "call_effect_source_max_output_path_leaves";
+static inline const std::string call_effect_sink_max_port_size_attribute =
+    "call_effect_sink_max_port_size";
+static inline const std::string
+    call_effect_sink_max_input_path_leaves_attribute =
+        "call_effect_sink_max_input_path_leaves";
+static inline const std::string max_number_iterations_attribute =
+    "max_number_iterations";
+static inline const std::string max_depth_class_properties_attribute =
+    "max_depth_class_properties";
+static inline const std::string max_call_chain_source_sink_distance_attribute =
+    "max_call_chain_source_sink_distance";
+static inline const std::string propagation_max_input_path_size_attribute =
+    "propagation_max_input_path_size";
+static inline const std::string propagation_max_input_path_leaves_attribute =
+    "propagation_max_input_path_leaves";
 
-Heuristics::Heuristics(std::size_t k_join_override_threshold,
-                       std::size_t k_android_join_override_threshold,
-                       std::optional<std::size_t> k_warn_override_threshold,
-                       std::size_t k_generation_max_port_size,
-                       std::size_t k_generation_max_output_path_leaves,
-                       std::size_t k_parameter_source_max_port_size,
-                       std::size_t k_parameter_source_max_output_path_leaves,
-                       std::size_t k_sink_max_port_size,
-                       std::size_t k_sink_max_input_path_leaves,
-                       std::size_t k_call_effect_source_max_port_size,
-                       std::size_t k_call_effect_source_max_output_path_leaves,
-                       std::size_t k_call_effect_sink_max_port_size,
-                       std::size_t k_call_effect_sink_max_input_path_leaves,
-                       std::size_t k_max_number_iterations,
-                       std::size_t k_max_depth_class_properties,
-                       std::size_t k_max_call_chain_source_sink_distance,
-                       std::size_t k_propagation_max_input_path_size,
-                       std::size_t k_propagation_max_input_path_leaves)
-    : k_join_override_threshold_(k_join_override_threshold),
-      k_android_join_override_threshold_(k_android_join_override_threshold),
-      k_warn_override_threshold_(k_warn_override_threshold),
-      k_generation_max_port_size_(k_generation_max_port_size),
-      k_generation_max_output_path_leaves_(k_generation_max_output_path_leaves),
-      k_parameter_source_max_port_size_(k_parameter_source_max_port_size),
-      k_parameter_source_max_output_path_leaves_(
-          k_parameter_source_max_output_path_leaves),
-      k_sink_max_port_size_(k_sink_max_port_size),
-      k_sink_max_input_path_leaves_(k_sink_max_input_path_leaves),
-      k_call_effect_source_max_port_size_(k_call_effect_source_max_port_size),
-      k_call_effect_source_max_output_path_leaves_(
-          k_call_effect_source_max_output_path_leaves),
-      k_call_effect_sink_max_port_size_(k_call_effect_sink_max_port_size),
-      k_call_effect_sink_max_input_path_leaves_(
-          k_call_effect_sink_max_input_path_leaves),
-      k_max_number_iterations_(k_max_number_iterations),
-      k_max_depth_class_properties_(k_max_depth_class_properties),
-      k_max_call_chain_source_sink_distance_(
-          k_max_call_chain_source_sink_distance),
-      k_propagation_max_input_path_size_(k_propagation_max_input_path_size),
-      k_propagation_max_input_path_leaves_(
-          k_propagation_max_input_path_leaves) {}
+Heuristics::Heuristics(std::size_t join_override_threshold,
+                       std::size_t android_join_override_threshold,
+                       std::optional<std::size_t> warn_override_threshold,
+                       std::size_t generation_max_port_size,
+                       std::size_t generation_max_output_path_leaves,
+                       std::size_t parameter_source_max_port_size,
+                       std::size_t parameter_source_max_output_path_leaves,
+                       std::size_t sink_max_port_size,
+                       std::size_t sink_max_input_path_leaves,
+                       std::size_t call_effect_source_max_port_size,
+                       std::size_t call_effect_source_max_output_path_leaves,
+                       std::size_t call_effect_sink_max_port_size,
+                       std::size_t call_effect_sink_max_input_path_leaves,
+                       std::size_t max_number_iterations,
+                       std::size_t max_depth_class_properties,
+                       std::size_t max_call_chain_source_sink_distance,
+                       std::size_t propagation_max_input_path_size,
+                       std::size_t propagation_max_input_path_leaves)
+    : join_override_threshold_(join_override_threshold),
+      android_join_override_threshold_(android_join_override_threshold),
+      warn_override_threshold_(warn_override_threshold),
+      generation_max_port_size_(generation_max_port_size),
+      generation_max_output_path_leaves_(generation_max_output_path_leaves),
+      parameter_source_max_port_size_(parameter_source_max_port_size),
+      parameter_source_max_output_path_leaves_(
+          parameter_source_max_output_path_leaves),
+      sink_max_port_size_(sink_max_port_size),
+      sink_max_input_path_leaves_(sink_max_input_path_leaves),
+      call_effect_source_max_port_size_(call_effect_source_max_port_size),
+      call_effect_source_max_output_path_leaves_(
+          call_effect_source_max_output_path_leaves),
+      call_effect_sink_max_port_size_(call_effect_sink_max_port_size),
+      call_effect_sink_max_input_path_leaves_(
+          call_effect_sink_max_input_path_leaves),
+      max_number_iterations_(max_number_iterations),
+      max_depth_class_properties_(max_depth_class_properties),
+      max_call_chain_source_sink_distance_(max_call_chain_source_sink_distance),
+      propagation_max_input_path_size_(propagation_max_input_path_size),
+      propagation_max_input_path_leaves_(propagation_max_input_path_leaves) {}
 
 Heuristics Heuristics::from_json(const Json::Value &value) {
   // Create an `Heuristics` object with the default values.
@@ -99,311 +99,301 @@ Heuristics Heuristics::from_json(const Json::Value &value) {
   JsonValidation::validate_object(value);
   JsonValidation::check_unexpected_members(
       value,
-      {k_join_override_threshold_attribute,
-       k_android_join_override_threshold_attribute,
-       k_warn_override_threshold_attribute,
-       k_generation_max_port_size_attribute,
-       k_generation_max_output_path_leaves_attribute,
-       k_parameter_source_max_port_size_attribute,
-       k_parameter_source_max_output_path_leaves_attribute,
-       k_sink_max_port_size_attribute, k_sink_max_input_path_leaves_attribute,
-       k_call_effect_source_max_port_size_attribute,
-       k_call_effect_source_max_output_path_leaves_attribute,
-       k_call_effect_sink_max_port_size_attribute,
-       k_call_effect_sink_max_input_path_leaves_attribute,
-       k_max_number_iterations_attribute,
-       k_max_depth_class_properties_attribute,
-       k_max_call_chain_source_sink_distance_attribute,
-       k_propagation_max_input_path_size_attribute,
-       k_propagation_max_input_path_leaves_attribute});
+      {join_override_threshold_attribute,
+       android_join_override_threshold_attribute,
+       warn_override_threshold_attribute, generation_max_port_size_attribute,
+       generation_max_output_path_leaves_attribute,
+       parameter_source_max_port_size_attribute,
+       parameter_source_max_output_path_leaves_attribute,
+       sink_max_port_size_attribute, sink_max_input_path_leaves_attribute,
+       call_effect_source_max_port_size_attribute,
+       call_effect_source_max_output_path_leaves_attribute,
+       call_effect_sink_max_port_size_attribute,
+       call_effect_sink_max_input_path_leaves_attribute,
+       max_number_iterations_attribute, max_depth_class_properties_attribute,
+       max_call_chain_source_sink_distance_attribute,
+       propagation_max_input_path_size_attribute,
+       propagation_max_input_path_leaves_attribute});
 
   // Set the heuristics parameters that are specified in the JSON document.
 
-  if (JsonValidation::has_field(value, k_join_override_threshold_attribute)) {
-    heuristics.set_k_join_override_threshold(JsonValidation::unsigned_integer(
-        value, k_join_override_threshold_attribute));
+  if (JsonValidation::has_field(value, join_override_threshold_attribute)) {
+    heuristics.set_join_override_threshold(JsonValidation::unsigned_integer(
+        value, join_override_threshold_attribute));
   }
 
   if (JsonValidation::has_field(value,
-                                k_android_join_override_threshold_attribute)) {
-    heuristics.set_k_android_join_override_threshold(
+                                android_join_override_threshold_attribute)) {
+    heuristics.set_android_join_override_threshold(
         JsonValidation::unsigned_integer(
-            value, k_android_join_override_threshold_attribute));
+            value, android_join_override_threshold_attribute));
   }
 
-  if (JsonValidation::has_field(value, k_warn_override_threshold_attribute)) {
-    heuristics.set_k_warn_override_threshold(JsonValidation::unsigned_integer(
-        value, k_warn_override_threshold_attribute));
+  if (JsonValidation::has_field(value, warn_override_threshold_attribute)) {
+    heuristics.set_warn_override_threshold(JsonValidation::unsigned_integer(
+        value, warn_override_threshold_attribute));
   }
 
-  if (JsonValidation::has_field(value, k_generation_max_port_size_attribute)) {
-    heuristics.set_k_generation_max_port_size(JsonValidation::unsigned_integer(
-        value, k_generation_max_port_size_attribute));
+  if (JsonValidation::has_field(value, generation_max_port_size_attribute)) {
+    heuristics.set_generation_max_port_size(JsonValidation::unsigned_integer(
+        value, generation_max_port_size_attribute));
+  }
+
+  if (JsonValidation::has_field(value,
+                                generation_max_output_path_leaves_attribute)) {
+    heuristics.set_generation_max_output_path_leaves(
+        JsonValidation::unsigned_integer(
+            value, generation_max_output_path_leaves_attribute));
+  }
+
+  if (JsonValidation::has_field(value,
+                                parameter_source_max_port_size_attribute)) {
+    heuristics.set_parameter_source_max_port_size(
+        JsonValidation::unsigned_integer(
+            value, parameter_source_max_port_size_attribute));
   }
 
   if (JsonValidation::has_field(
-          value, k_generation_max_output_path_leaves_attribute)) {
-    heuristics.set_k_generation_max_output_path_leaves(
+          value, parameter_source_max_output_path_leaves_attribute)) {
+    heuristics.set_parameter_source_max_output_path_leaves(
         JsonValidation::unsigned_integer(
-            value, k_generation_max_output_path_leaves_attribute));
+            value, parameter_source_max_output_path_leaves_attribute));
+  }
+
+  if (JsonValidation::has_field(value, sink_max_port_size_attribute)) {
+    heuristics.set_sink_max_port_size(
+        JsonValidation::unsigned_integer(value, sink_max_port_size_attribute));
+  }
+
+  if (JsonValidation::has_field(value, sink_max_input_path_leaves_attribute)) {
+    heuristics.set_sink_max_input_path_leaves(JsonValidation::unsigned_integer(
+        value, sink_max_input_path_leaves_attribute));
   }
 
   if (JsonValidation::has_field(value,
-                                k_parameter_source_max_port_size_attribute)) {
-    heuristics.set_k_parameter_source_max_port_size(
+                                call_effect_source_max_port_size_attribute)) {
+    heuristics.set_call_effect_source_max_port_size(
         JsonValidation::unsigned_integer(
-            value, k_parameter_source_max_port_size_attribute));
+            value, call_effect_source_max_port_size_attribute));
   }
 
   if (JsonValidation::has_field(
-          value, k_parameter_source_max_output_path_leaves_attribute)) {
-    heuristics.set_k_parameter_source_max_output_path_leaves(
+          value, call_effect_source_max_output_path_leaves_attribute)) {
+    heuristics.set_call_effect_source_max_output_path_leaves(
         JsonValidation::unsigned_integer(
-            value, k_parameter_source_max_output_path_leaves_attribute));
-  }
-
-  if (JsonValidation::has_field(value, k_sink_max_port_size_attribute)) {
-    heuristics.set_k_sink_max_port_size(JsonValidation::unsigned_integer(
-        value, k_sink_max_port_size_attribute));
+            value, call_effect_source_max_output_path_leaves_attribute));
   }
 
   if (JsonValidation::has_field(value,
-                                k_sink_max_input_path_leaves_attribute)) {
-    heuristics.set_k_sink_max_input_path_leaves(
+                                call_effect_sink_max_port_size_attribute)) {
+    heuristics.set_call_effect_sink_max_port_size(
         JsonValidation::unsigned_integer(
-            value, k_sink_max_input_path_leaves_attribute));
-  }
-
-  if (JsonValidation::has_field(value,
-                                k_call_effect_source_max_port_size_attribute)) {
-    heuristics.set_k_call_effect_source_max_port_size(
-        JsonValidation::unsigned_integer(
-            value, k_call_effect_source_max_port_size_attribute));
+            value, call_effect_sink_max_port_size_attribute));
   }
 
   if (JsonValidation::has_field(
-          value, k_call_effect_source_max_output_path_leaves_attribute)) {
-    heuristics.set_k_call_effect_source_max_output_path_leaves(
+          value, call_effect_sink_max_input_path_leaves_attribute)) {
+    heuristics.set_call_effect_sink_max_input_path_leaves(
         JsonValidation::unsigned_integer(
-            value, k_call_effect_source_max_output_path_leaves_attribute));
+            value, call_effect_sink_max_input_path_leaves_attribute));
   }
 
-  if (JsonValidation::has_field(value,
-                                k_call_effect_sink_max_port_size_attribute)) {
-    heuristics.set_k_call_effect_sink_max_port_size(
-        JsonValidation::unsigned_integer(
-            value, k_call_effect_sink_max_port_size_attribute));
+  if (JsonValidation::has_field(value, max_number_iterations_attribute)) {
+    heuristics.set_max_number_iterations(JsonValidation::unsigned_integer(
+        value, max_number_iterations_attribute));
   }
 
-  if (JsonValidation::has_field(
-          value, k_call_effect_sink_max_input_path_leaves_attribute)) {
-    heuristics.set_k_call_effect_sink_max_input_path_leaves(
-        JsonValidation::unsigned_integer(
-            value, k_call_effect_sink_max_input_path_leaves_attribute));
-  }
-
-  if (JsonValidation::has_field(value, k_max_number_iterations_attribute)) {
-    heuristics.set_k_max_number_iterations(JsonValidation::unsigned_integer(
-        value, k_max_number_iterations_attribute));
-  }
-
-  if (JsonValidation::has_field(value,
-                                k_max_depth_class_properties_attribute)) {
-    heuristics.set_k_max_depth_class_properties(
-        JsonValidation::unsigned_integer(
-            value, k_max_depth_class_properties_attribute));
+  if (JsonValidation::has_field(value, max_depth_class_properties_attribute)) {
+    heuristics.set_max_depth_class_properties(JsonValidation::unsigned_integer(
+        value, max_depth_class_properties_attribute));
   }
 
   if (JsonValidation::has_field(
-          value, k_max_call_chain_source_sink_distance_attribute)) {
-    heuristics.set_k_max_call_chain_source_sink_distance(
+          value, max_call_chain_source_sink_distance_attribute)) {
+    heuristics.set_max_call_chain_source_sink_distance(
         JsonValidation::unsigned_integer(
-            value, k_max_call_chain_source_sink_distance_attribute));
+            value, max_call_chain_source_sink_distance_attribute));
   }
 
   if (JsonValidation::has_field(value,
-                                k_propagation_max_input_path_size_attribute)) {
-    heuristics.set_k_propagation_max_input_path_size(
+                                propagation_max_input_path_size_attribute)) {
+    heuristics.set_propagation_max_input_path_size(
         JsonValidation::unsigned_integer(
-            value, k_propagation_max_input_path_size_attribute));
+            value, propagation_max_input_path_size_attribute));
   }
 
-  if (JsonValidation::has_field(
-          value, k_propagation_max_input_path_leaves_attribute)) {
-    heuristics.set_k_propagation_max_input_path_leaves(
+  if (JsonValidation::has_field(value,
+                                propagation_max_input_path_leaves_attribute)) {
+    heuristics.set_propagation_max_input_path_leaves(
         JsonValidation::unsigned_integer(
-            value, k_propagation_max_input_path_leaves_attribute));
+            value, propagation_max_input_path_leaves_attribute));
   }
 
   return heuristics;
 }
 
-std::size_t Heuristics::k_join_override_threshold() const {
-  return this->k_join_override_threshold_;
+std::size_t Heuristics::join_override_threshold() const {
+  return this->join_override_threshold_;
 }
 
-void Heuristics::set_k_join_override_threshold(
-    std::size_t k_join_override_threshold) {
-  this->k_join_override_threshold_ = k_join_override_threshold;
+void Heuristics::set_join_override_threshold(
+    std::size_t join_override_threshold) {
+  this->join_override_threshold_ = join_override_threshold;
 }
 
-std::size_t Heuristics::k_android_join_override_threshold() const {
-  return this->k_android_join_override_threshold_;
+std::size_t Heuristics::android_join_override_threshold() const {
+  return this->android_join_override_threshold_;
 }
 
-void Heuristics::set_k_android_join_override_threshold(
-    std::size_t k_android_join_override_threshold) {
-  this->k_android_join_override_threshold_ = k_android_join_override_threshold;
+void Heuristics::set_android_join_override_threshold(
+    std::size_t android_join_override_threshold) {
+  this->android_join_override_threshold_ = android_join_override_threshold;
 }
 
-const std::optional<std::size_t> Heuristics::k_warn_override_threshold() const {
-  return this->k_warn_override_threshold_;
+const std::optional<std::size_t> Heuristics::warn_override_threshold() const {
+  return this->warn_override_threshold_;
 }
 
-void Heuristics::set_k_warn_override_threshold(
-    std::size_t k_warn_override_threshold) {
-  this->k_warn_override_threshold_ = k_warn_override_threshold;
+void Heuristics::set_warn_override_threshold(
+    std::size_t warn_override_threshold) {
+  this->warn_override_threshold_ = warn_override_threshold;
 }
 
-std::size_t Heuristics::k_generation_max_port_size() const {
-  return this->k_generation_max_port_size_;
+std::size_t Heuristics::generation_max_port_size() const {
+  return this->generation_max_port_size_;
 }
 
-void Heuristics::set_k_generation_max_port_size(
-    std::size_t k_generation_max_port_size) {
-  this->k_generation_max_port_size_ = k_generation_max_port_size;
+void Heuristics::set_generation_max_port_size(
+    std::size_t generation_max_port_size) {
+  this->generation_max_port_size_ = generation_max_port_size;
 }
 
-std::size_t Heuristics::k_generation_max_output_path_leaves() const {
-  return this->k_generation_max_output_path_leaves_;
+std::size_t Heuristics::generation_max_output_path_leaves() const {
+  return this->generation_max_output_path_leaves_;
 }
 
-void Heuristics::set_k_generation_max_output_path_leaves(
-    std::size_t k_generation_max_output_path_leaves) {
-  this->k_generation_max_output_path_leaves_ =
-      k_generation_max_output_path_leaves;
+void Heuristics::set_generation_max_output_path_leaves(
+    std::size_t generation_max_output_path_leaves) {
+  this->generation_max_output_path_leaves_ = generation_max_output_path_leaves;
 }
 
-std::size_t Heuristics::k_parameter_source_max_port_size() const {
-  return this->k_parameter_source_max_port_size_;
+std::size_t Heuristics::parameter_source_max_port_size() const {
+  return this->parameter_source_max_port_size_;
 }
 
-void Heuristics::set_k_parameter_source_max_port_size(
-    std::size_t k_parameter_source_max_port_size) {
-  this->k_parameter_source_max_port_size_ = k_parameter_source_max_port_size;
+void Heuristics::set_parameter_source_max_port_size(
+    std::size_t parameter_source_max_port_size) {
+  this->parameter_source_max_port_size_ = parameter_source_max_port_size;
 }
 
-std::size_t Heuristics::k_parameter_source_max_output_path_leaves() const {
-  return this->k_parameter_source_max_output_path_leaves_;
+std::size_t Heuristics::parameter_source_max_output_path_leaves() const {
+  return this->parameter_source_max_output_path_leaves_;
 }
 
-void Heuristics::set_k_parameter_source_max_output_path_leaves(
-    std::size_t k_parameter_source_max_output_path_leaves) {
-  this->k_parameter_source_max_output_path_leaves_ =
-      k_parameter_source_max_output_path_leaves;
+void Heuristics::set_parameter_source_max_output_path_leaves(
+    std::size_t parameter_source_max_output_path_leaves) {
+  this->parameter_source_max_output_path_leaves_ =
+      parameter_source_max_output_path_leaves;
 }
 
-std::size_t Heuristics::k_sink_max_port_size() const {
-  return this->k_sink_max_port_size_;
+std::size_t Heuristics::sink_max_port_size() const {
+  return this->sink_max_port_size_;
 }
 
-void Heuristics::set_k_sink_max_port_size(std::size_t k_sink_max_port_size) {
-  this->k_sink_max_port_size_ = k_sink_max_port_size;
+void Heuristics::set_sink_max_port_size(std::size_t sink_max_port_size) {
+  this->sink_max_port_size_ = sink_max_port_size;
 }
 
-std::size_t Heuristics::k_sink_max_input_path_leaves() const {
-  return this->k_sink_max_input_path_leaves_;
+std::size_t Heuristics::sink_max_input_path_leaves() const {
+  return this->sink_max_input_path_leaves_;
 }
 
-void Heuristics::set_k_sink_max_input_path_leaves(
-    std::size_t k_sink_max_input_path_leaves) {
-  this->k_sink_max_input_path_leaves_ = k_sink_max_input_path_leaves;
+void Heuristics::set_sink_max_input_path_leaves(
+    std::size_t sink_max_input_path_leaves) {
+  this->sink_max_input_path_leaves_ = sink_max_input_path_leaves;
 }
 
-std::size_t Heuristics::k_call_effect_source_max_port_size() const {
-  return this->k_call_effect_source_max_port_size_;
+std::size_t Heuristics::call_effect_source_max_port_size() const {
+  return this->call_effect_source_max_port_size_;
 }
 
-void Heuristics::set_k_call_effect_source_max_port_size(
-    std::size_t k_call_effect_source_max_port_size) {
-  this->k_call_effect_source_max_port_size_ =
-      k_call_effect_source_max_port_size;
+void Heuristics::set_call_effect_source_max_port_size(
+    std::size_t call_effect_source_max_port_size) {
+  this->call_effect_source_max_port_size_ = call_effect_source_max_port_size;
 }
 
-std::size_t Heuristics::k_call_effect_source_max_output_path_leaves() const {
-  return this->k_call_effect_source_max_output_path_leaves_;
+std::size_t Heuristics::call_effect_source_max_output_path_leaves() const {
+  return this->call_effect_source_max_output_path_leaves_;
 }
 
-void Heuristics::set_k_call_effect_source_max_output_path_leaves(
-    std::size_t k_call_effect_source_max_output_path_leaves) {
-  this->k_call_effect_source_max_output_path_leaves_ =
-      k_call_effect_source_max_output_path_leaves;
+void Heuristics::set_call_effect_source_max_output_path_leaves(
+    std::size_t call_effect_source_max_output_path_leaves) {
+  this->call_effect_source_max_output_path_leaves_ =
+      call_effect_source_max_output_path_leaves;
 }
 
-std::size_t Heuristics::k_call_effect_sink_max_port_size() const {
-  return this->k_call_effect_sink_max_port_size_;
+std::size_t Heuristics::call_effect_sink_max_port_size() const {
+  return this->call_effect_sink_max_port_size_;
 }
 
-void Heuristics::set_k_call_effect_sink_max_port_size(
-    std::size_t k_call_effect_sink_max_port_size) {
-  this->k_call_effect_sink_max_port_size_ = k_call_effect_sink_max_port_size;
+void Heuristics::set_call_effect_sink_max_port_size(
+    std::size_t call_effect_sink_max_port_size) {
+  this->call_effect_sink_max_port_size_ = call_effect_sink_max_port_size;
 }
 
-std::size_t Heuristics::k_call_effect_sink_max_input_path_leaves() const {
-  return this->k_call_effect_sink_max_input_path_leaves_;
+std::size_t Heuristics::call_effect_sink_max_input_path_leaves() const {
+  return this->call_effect_sink_max_input_path_leaves_;
 }
 
-void Heuristics::set_k_call_effect_sink_max_input_path_leaves(
-    std::size_t k_call_effect_sink_max_input_path_leaves) {
-  this->k_call_effect_sink_max_input_path_leaves_ =
-      k_call_effect_sink_max_input_path_leaves;
+void Heuristics::set_call_effect_sink_max_input_path_leaves(
+    std::size_t call_effect_sink_max_input_path_leaves) {
+  this->call_effect_sink_max_input_path_leaves_ =
+      call_effect_sink_max_input_path_leaves;
 }
 
-std::size_t Heuristics::k_max_number_iterations() const {
-  return this->k_max_number_iterations_;
+std::size_t Heuristics::max_number_iterations() const {
+  return this->max_number_iterations_;
 }
 
-void Heuristics::set_k_max_number_iterations(
-    std::size_t k_max_number_iterations) {
-  this->k_max_number_iterations_ = k_max_number_iterations;
+void Heuristics::set_max_number_iterations(std::size_t max_number_iterations) {
+  this->max_number_iterations_ = max_number_iterations;
 }
 
-std::size_t Heuristics::k_max_depth_class_properties() const {
-  return this->k_max_depth_class_properties_;
+std::size_t Heuristics::max_depth_class_properties() const {
+  return this->max_depth_class_properties_;
 }
 
-void Heuristics::set_k_max_depth_class_properties(
-    std::size_t k_max_depth_class_properties) {
-  this->k_max_depth_class_properties_ = k_max_depth_class_properties;
+void Heuristics::set_max_depth_class_properties(
+    std::size_t max_depth_class_properties) {
+  this->max_depth_class_properties_ = max_depth_class_properties;
 }
 
-std::size_t Heuristics::k_max_call_chain_source_sink_distance() const {
-  return this->k_max_call_chain_source_sink_distance_;
+std::size_t Heuristics::max_call_chain_source_sink_distance() const {
+  return this->max_call_chain_source_sink_distance_;
 }
 
-void Heuristics::set_k_max_call_chain_source_sink_distance(
-    std::size_t k_max_call_chain_source_sink_distance) {
-  this->k_max_call_chain_source_sink_distance_ =
-      k_max_call_chain_source_sink_distance;
+void Heuristics::set_max_call_chain_source_sink_distance(
+    std::size_t max_call_chain_source_sink_distance) {
+  this->max_call_chain_source_sink_distance_ =
+      max_call_chain_source_sink_distance;
 }
 
-std::size_t Heuristics::k_propagation_max_input_path_size() const {
-  return this->k_propagation_max_input_path_size_;
+std::size_t Heuristics::propagation_max_input_path_size() const {
+  return this->propagation_max_input_path_size_;
 }
 
-void Heuristics::set_k_propagation_max_input_path_size(
-    std::size_t k_propagation_max_input_path_size) {
-  this->k_propagation_max_input_path_size_ = k_propagation_max_input_path_size;
+void Heuristics::set_propagation_max_input_path_size(
+    std::size_t propagation_max_input_path_size) {
+  this->propagation_max_input_path_size_ = propagation_max_input_path_size;
 }
 
-std::size_t Heuristics::k_propagation_max_input_path_leaves() const {
-  return this->k_propagation_max_input_path_leaves_;
+std::size_t Heuristics::propagation_max_input_path_leaves() const {
+  return this->propagation_max_input_path_leaves_;
 }
 
-void Heuristics::set_k_propagation_max_input_path_leaves(
-    std::size_t k_propagation_max_input_path_leaves) {
-  this->k_propagation_max_input_path_leaves_ =
-      k_propagation_max_input_path_leaves;
+void Heuristics::set_propagation_max_input_path_leaves(
+    std::size_t propagation_max_input_path_leaves) {
+  this->propagation_max_input_path_leaves_ = propagation_max_input_path_leaves;
 }
 
 } // namespace marianatrench

--- a/source/Heuristics.h
+++ b/source/Heuristics.h
@@ -17,39 +17,38 @@ namespace marianatrench {
 class Heuristics final {
 public:
   explicit Heuristics(
-      std::size_t k_join_override_threshold = k_join_override_threshold_default,
-      std::size_t k_android_join_override_threshold =
-          k_android_join_override_threshold_default,
-      std::optional<std::size_t> k_warn_override_threshold =
-          k_warn_override_threshold_default,
-      std::size_t k_generation_max_port_size =
-          k_generation_max_port_size_default,
-      std::size_t k_generation_max_output_path_leaves =
-          k_generation_max_output_path_leaves_default,
-      std::size_t k_parameter_source_max_port_size =
-          k_parameter_source_max_port_size_default,
-      std::size_t k_parameter_source_max_output_path_leaves =
-          k_parameter_source_max_output_path_leaves_default,
-      std::size_t k_sink_max_port_size = k_sink_max_port_size_default,
-      std::size_t k_sink_max_input_path_leaves =
-          k_sink_max_input_path_leaves_default,
-      std::size_t k_call_effect_source_max_port_size =
-          k_call_effect_source_max_port_size_default,
-      std::size_t k_call_effect_source_max_output_path_leaves =
-          k_call_effect_source_max_output_path_leaves_default,
-      std::size_t k_call_effect_sink_max_port_size =
-          k_call_effect_sink_max_port_size_default,
-      std::size_t k_call_effect_sink_max_input_path_leaves =
-          k_call_effect_sink_max_input_path_leaves_default,
-      std::size_t k_max_number_iterations = k_max_number_iterations_default,
-      std::size_t k_max_depth_class_properties =
-          k_max_depth_class_properties_default,
-      std::size_t k_max_call_chain_source_sink_distance =
-          k_max_call_chain_source_sink_distance_default,
-      std::size_t k_propagation_max_input_path_size =
-          k_propagation_max_input_path_size_default,
-      std::size_t k_propagation_max_input_path_leaves =
-          k_propagation_max_input_path_leaves_default);
+      std::size_t join_override_threshold = join_override_threshold_default,
+      std::size_t android_join_override_threshold =
+          android_join_override_threshold_default,
+      std::optional<std::size_t> warn_override_threshold =
+          warn_override_threshold_default,
+      std::size_t generation_max_port_size = generation_max_port_size_default,
+      std::size_t generation_max_output_path_leaves =
+          generation_max_output_path_leaves_default,
+      std::size_t parameter_source_max_port_size =
+          parameter_source_max_port_size_default,
+      std::size_t parameter_source_max_output_path_leaves =
+          parameter_source_max_output_path_leaves_default,
+      std::size_t sink_max_port_size = sink_max_port_size_default,
+      std::size_t sink_max_input_path_leaves =
+          sink_max_input_path_leaves_default,
+      std::size_t call_effect_source_max_port_size =
+          call_effect_source_max_port_size_default,
+      std::size_t call_effect_source_max_output_path_leaves =
+          call_effect_source_max_output_path_leaves_default,
+      std::size_t call_effect_sink_max_port_size =
+          call_effect_sink_max_port_size_default,
+      std::size_t call_effect_sink_max_input_path_leaves =
+          call_effect_sink_max_input_path_leaves_default,
+      std::size_t max_number_iterations = max_number_iterations_default,
+      std::size_t max_depth_class_properties =
+          max_depth_class_properties_default,
+      std::size_t max_call_chain_source_sink_distance =
+          max_call_chain_source_sink_distance_default,
+      std::size_t propagation_max_input_path_size =
+          propagation_max_input_path_size_default,
+      std::size_t propagation_max_input_path_leaves =
+          propagation_max_input_path_leaves_default);
 
   bool operator==(const Heuristics &other) const;
 
@@ -59,28 +58,28 @@ public:
    * When a method has a set of overrides greater than this threshold, we do not
    * join all overrides at call sites.
    */
-  std::size_t k_join_override_threshold() const;
-  constexpr static std::size_t k_join_override_threshold_default = 40;
-  void set_k_join_override_threshold(std::size_t k_join_override_threshold);
+  std::size_t join_override_threshold() const;
+  constexpr static std::size_t join_override_threshold_default = 40;
+  void set_join_override_threshold(std::size_t join_override_threshold);
 
   /**
    * When an android/java/google method has a set of overrides and greater than
    * this threshold, we do not join all overrides at call sites.
    */
-  std::size_t k_android_join_override_threshold() const;
-  constexpr static std::size_t k_android_join_override_threshold_default = 10;
-  void set_k_android_join_override_threshold(
-      std::size_t k_android_join_override_threshold);
+  std::size_t android_join_override_threshold() const;
+  constexpr static std::size_t android_join_override_threshold_default = 10;
+  void set_android_join_override_threshold(
+      std::size_t android_join_override_threshold);
 
   /**
    * When a method which has a set of overrides greater than this threshold that
    * is not marked with `NoJoinVirtualOverrides` is called at least once, we
    * print a warning.
    */
-  const std::optional<std::size_t> k_warn_override_threshold() const;
-  constexpr static std::optional<std::size_t>
-      k_warn_override_threshold_default = std::nullopt;
-  void set_k_warn_override_threshold(std::size_t k_warn_override_threshold);
+  const std::optional<std::size_t> warn_override_threshold() const;
+  constexpr static std::optional<std::size_t> warn_override_threshold_default =
+      std::nullopt;
+  void set_warn_override_threshold(std::size_t warn_override_threshold);
 
   /**
    * Maximum height of a taint (source or sink) tree after widening.
@@ -93,63 +92,62 @@ public:
   /**
    * Maximum size of the port of a generation.
    */
-  std::size_t k_generation_max_port_size() const;
-  constexpr static std::size_t k_generation_max_port_size_default = 4;
-  void set_k_generation_max_port_size(std::size_t k_generation_max_port_size);
+  std::size_t generation_max_port_size() const;
+  constexpr static std::size_t generation_max_port_size_default = 4;
+  void set_generation_max_port_size(std::size_t generation_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of output paths of generations.
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
-  std::size_t k_generation_max_output_path_leaves() const;
-  constexpr static std::size_t k_generation_max_output_path_leaves_default = 20;
-  void set_k_generation_max_output_path_leaves(
-      std::size_t k_generation_max_output_path_leaves);
+  std::size_t generation_max_output_path_leaves() const;
+  constexpr static std::size_t generation_max_output_path_leaves_default = 20;
+  void set_generation_max_output_path_leaves(
+      std::size_t generation_max_output_path_leaves);
 
   /**
    * Maximum size of the port of a parameter source.
    */
-  std::size_t k_parameter_source_max_port_size() const;
-  constexpr static std::size_t k_parameter_source_max_port_size_default = 4;
-  void set_k_parameter_source_max_port_size(
-      std::size_t k_parameter_source_max_port_size);
+  std::size_t parameter_source_max_port_size() const;
+  constexpr static std::size_t parameter_source_max_port_size_default = 4;
+  void set_parameter_source_max_port_size(
+      std::size_t parameter_source_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of output paths of parameter sources.
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
-  std::size_t k_parameter_source_max_output_path_leaves() const;
-  constexpr static std::size_t
-      k_parameter_source_max_output_path_leaves_default = 20;
-  void set_k_parameter_source_max_output_path_leaves(
-      std::size_t k_parameter_source_max_output_path_leaves);
+  std::size_t parameter_source_max_output_path_leaves() const;
+  constexpr static std::size_t parameter_source_max_output_path_leaves_default =
+      20;
+  void set_parameter_source_max_output_path_leaves(
+      std::size_t parameter_source_max_output_path_leaves);
 
   /**
    * Maximum size of the port of a sink.
    */
-  std::size_t k_sink_max_port_size() const;
-  constexpr static std::size_t k_sink_max_port_size_default = 4;
-  void set_k_sink_max_port_size(std::size_t k_sink_max_port_size);
+  std::size_t sink_max_port_size() const;
+  constexpr static std::size_t sink_max_port_size_default = 4;
+  void set_sink_max_port_size(std::size_t sink_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of input paths of sinks.
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
-  std::size_t k_sink_max_input_path_leaves() const;
-  constexpr static std::size_t k_sink_max_input_path_leaves_default = 20;
-  void
-  set_k_sink_max_input_path_leaves(std::size_t k_sink_max_input_path_leaves);
+  std::size_t sink_max_input_path_leaves() const;
+  constexpr static std::size_t sink_max_input_path_leaves_default = 20;
+  void set_sink_max_input_path_leaves(std::size_t sink_max_input_path_leaves);
 
   /**
    * Maximum size of the port of a call effect source.
    */
-  std::size_t k_call_effect_source_max_port_size() const;
-  constexpr static std::size_t k_call_effect_source_max_port_size_default = 4;
-  void set_k_call_effect_source_max_port_size(
-      std::size_t k_call_effect_source_max_port_size);
+  std::size_t call_effect_source_max_port_size() const;
+  constexpr static std::size_t call_effect_source_max_port_size_default = 4;
+  void set_call_effect_source_max_port_size(
+      std::size_t call_effect_source_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of output paths of call effect
@@ -157,37 +155,37 @@ public:
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
-  std::size_t k_call_effect_source_max_output_path_leaves() const;
+  std::size_t call_effect_source_max_output_path_leaves() const;
   constexpr static std::size_t
-      k_call_effect_source_max_output_path_leaves_default = 20;
-  void set_k_call_effect_source_max_output_path_leaves(
-      std::size_t k_call_effect_source_max_output_path_leaves);
+      call_effect_source_max_output_path_leaves_default = 20;
+  void set_call_effect_source_max_output_path_leaves(
+      std::size_t call_effect_source_max_output_path_leaves);
 
   /**
    * Maximum size of the port of a call effect sink.
    */
-  std::size_t k_call_effect_sink_max_port_size() const;
-  constexpr static std::size_t k_call_effect_sink_max_port_size_default = 4;
-  void set_k_call_effect_sink_max_port_size(
-      std::size_t k_call_effect_sink_max_port_size);
+  std::size_t call_effect_sink_max_port_size() const;
+  constexpr static std::size_t call_effect_sink_max_port_size_default = 4;
+  void set_call_effect_sink_max_port_size(
+      std::size_t call_effect_sink_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of input paths of call effect sinks.
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
-  std::size_t k_call_effect_sink_max_input_path_leaves() const;
-  constexpr static std::size_t
-      k_call_effect_sink_max_input_path_leaves_default = 20;
-  void set_k_call_effect_sink_max_input_path_leaves(
-      std::size_t k_call_effect_sink_max_input_path_leaves);
+  std::size_t call_effect_sink_max_input_path_leaves() const;
+  constexpr static std::size_t call_effect_sink_max_input_path_leaves_default =
+      20;
+  void set_call_effect_sink_max_input_path_leaves(
+      std::size_t call_effect_sink_max_input_path_leaves);
 
   /**
    * Maximum number of global iterations before we abort the analysis.
    */
-  std::size_t k_max_number_iterations() const;
-  constexpr static std::size_t k_max_number_iterations_default = 150;
-  void set_k_max_number_iterations(std::size_t k_max_number_iterations);
+  std::size_t max_number_iterations() const;
+  constexpr static std::size_t max_number_iterations_default = 150;
+  void set_max_number_iterations(std::size_t max_number_iterations);
 
   /**
    * Maximum number of local positions per frame.
@@ -199,27 +197,25 @@ public:
   /**
    * Maximum depth of dependency graph traversal to find class properties.
    */
-  std::size_t k_max_depth_class_properties() const;
-  constexpr static std::size_t k_max_depth_class_properties_default = 10;
-  void
-  set_k_max_depth_class_properties(std::size_t k_max_depth_class_properties);
+  std::size_t max_depth_class_properties() const;
+  constexpr static std::size_t max_depth_class_properties_default = 10;
+  void set_max_depth_class_properties(std::size_t max_depth_class_properties);
 
   /**
    * Maximum number of hops that can be tracked for a call chain issue.
    */
-  std::size_t k_max_call_chain_source_sink_distance() const;
-  constexpr static std::size_t k_max_call_chain_source_sink_distance_default =
-      10;
-  void set_k_max_call_chain_source_sink_distance(
-      std::size_t k_max_call_chain_source_sink_distance);
+  std::size_t max_call_chain_source_sink_distance() const;
+  constexpr static std::size_t max_call_chain_source_sink_distance_default = 10;
+  void set_max_call_chain_source_sink_distance(
+      std::size_t max_call_chain_source_sink_distance);
 
   /**
    * Maximum size of the input access path of a propagation.
    */
-  std::size_t k_propagation_max_input_path_size() const;
-  constexpr static std::size_t k_propagation_max_input_path_size_default = 4;
-  void set_k_propagation_max_input_path_size(
-      std::size_t k_propagation_max_input_path_size);
+  std::size_t propagation_max_input_path_size() const;
+  constexpr static std::size_t propagation_max_input_path_size_default = 4;
+  void set_propagation_max_input_path_size(
+      std::size_t propagation_max_input_path_size);
 
   /**
    * Maximum size of the output access path of a propagation.
@@ -229,10 +225,10 @@ public:
   /**
    * Maximum number of leaves in the tree of input paths of propagations.
    */
-  std::size_t k_propagation_max_input_path_leaves() const;
-  constexpr static std::size_t k_propagation_max_input_path_leaves_default = 4;
-  void set_k_propagation_max_input_path_leaves(
-      std::size_t k_propagation_max_input_path_leaves);
+  std::size_t propagation_max_input_path_leaves() const;
+  constexpr static std::size_t propagation_max_input_path_leaves_default = 4;
+  void set_propagation_max_input_path_leaves(
+      std::size_t propagation_max_input_path_leaves);
 
   /**
    * Maximum number of leaves in the tree of output paths of propagations.
@@ -255,24 +251,24 @@ public:
   constexpr static std::uint32_t kPropagationMaxCollapseDepth = 4;
 
 private:
-  std::size_t k_join_override_threshold_;
-  std::size_t k_android_join_override_threshold_;
-  std::optional<std::size_t> k_warn_override_threshold_;
-  std::size_t k_generation_max_port_size_;
-  std::size_t k_generation_max_output_path_leaves_;
-  std::size_t k_parameter_source_max_port_size_;
-  std::size_t k_parameter_source_max_output_path_leaves_;
-  std::size_t k_sink_max_port_size_;
-  std::size_t k_sink_max_input_path_leaves_;
-  std::size_t k_call_effect_source_max_port_size_;
-  std::size_t k_call_effect_source_max_output_path_leaves_;
-  std::size_t k_call_effect_sink_max_port_size_;
-  std::size_t k_call_effect_sink_max_input_path_leaves_;
-  std::size_t k_max_number_iterations_;
-  std::size_t k_max_depth_class_properties_;
-  std::size_t k_max_call_chain_source_sink_distance_;
-  std::size_t k_propagation_max_input_path_size_;
-  std::size_t k_propagation_max_input_path_leaves_;
+  std::size_t join_override_threshold_;
+  std::size_t android_join_override_threshold_;
+  std::optional<std::size_t> warn_override_threshold_;
+  std::size_t generation_max_port_size_;
+  std::size_t generation_max_output_path_leaves_;
+  std::size_t parameter_source_max_port_size_;
+  std::size_t parameter_source_max_output_path_leaves_;
+  std::size_t sink_max_port_size_;
+  std::size_t sink_max_input_path_leaves_;
+  std::size_t call_effect_source_max_port_size_;
+  std::size_t call_effect_source_max_output_path_leaves_;
+  std::size_t call_effect_sink_max_port_size_;
+  std::size_t call_effect_sink_max_input_path_leaves_;
+  std::size_t max_number_iterations_;
+  std::size_t max_depth_class_properties_;
+  std::size_t max_call_chain_source_sink_distance_;
+  std::size_t propagation_max_input_path_size_;
+  std::size_t propagation_max_input_path_leaves_;
 };
 
 } // namespace marianatrench

--- a/source/Heuristics.h
+++ b/source/Heuristics.h
@@ -10,77 +10,146 @@
 #include <cstdint>
 #include <optional>
 
+#include <json/json.h>
+
 namespace marianatrench {
 
-class Heuristics {
- public:
+class Heuristics final {
+public:
+  explicit Heuristics(
+      std::size_t k_join_override_threshold = k_join_override_threshold_default,
+      std::size_t k_android_join_override_threshold =
+          k_android_join_override_threshold_default,
+      std::optional<std::size_t> k_warn_override_threshold =
+          k_warn_override_threshold_default,
+      std::size_t k_generation_max_port_size =
+          k_generation_max_port_size_default,
+      std::size_t k_generation_max_output_path_leaves =
+          k_generation_max_output_path_leaves_default,
+      std::size_t k_parameter_source_max_port_size =
+          k_parameter_source_max_port_size_default,
+      std::size_t k_parameter_source_max_output_path_leaves =
+          k_parameter_source_max_output_path_leaves_default,
+      std::size_t k_sink_max_port_size = k_sink_max_port_size_default,
+      std::size_t k_sink_max_input_path_leaves =
+          k_sink_max_input_path_leaves_default,
+      std::size_t k_call_effect_source_max_port_size =
+          k_call_effect_source_max_port_size_default,
+      std::size_t k_call_effect_source_max_output_path_leaves =
+          k_call_effect_source_max_output_path_leaves_default,
+      std::size_t k_call_effect_sink_max_port_size =
+          k_call_effect_sink_max_port_size_default,
+      std::size_t k_call_effect_sink_max_input_path_leaves =
+          k_call_effect_sink_max_input_path_leaves_default,
+      std::size_t k_max_number_iterations = k_max_number_iterations_default,
+      std::size_t k_max_depth_class_properties =
+          k_max_depth_class_properties_default,
+      std::size_t k_max_call_chain_source_sink_distance =
+          k_max_call_chain_source_sink_distance_default,
+      std::size_t k_propagation_max_input_path_size =
+          k_propagation_max_input_path_size_default,
+      std::size_t k_propagation_max_input_path_leaves =
+          k_propagation_max_input_path_leaves_default);
+
+  bool operator==(const Heuristics &other) const;
+
+  static Heuristics from_json(const Json::Value &value);
+
   /**
    * When a method has a set of overrides greater than this threshold, we do not
    * join all overrides at call sites.
    */
-  constexpr static std::size_t kJoinOverrideThreshold = 40;
+  std::size_t k_join_override_threshold() const;
+  constexpr static std::size_t k_join_override_threshold_default = 40;
+  void set_k_join_override_threshold(std::size_t k_join_override_threshold);
 
   /**
    * When an android/java/google method has a set of overrides and greater than
    * this threshold, we do not join all overrides at call sites.
    */
-  constexpr static std::size_t kAndroidJoinOverrideThreshold = 10;
+  std::size_t k_android_join_override_threshold() const;
+  constexpr static std::size_t k_android_join_override_threshold_default = 10;
+  void set_k_android_join_override_threshold(
+      std::size_t k_android_join_override_threshold);
 
   /**
-   * When a method has a set of overrides greater than this threshold, is called
-   * at least once and is not marked with `NoJoinVirtualOverrides`, we print a
-   * warning.
+   * When a method which has a set of overrides greater than this threshold that
+   * is not marked with `NoJoinVirtualOverrides` is called at least once, we
+   * print a warning.
    */
-  constexpr static std::optional<std::size_t> kWarnOverrideThreshold =
-      std::nullopt;
+  const std::optional<std::size_t> k_warn_override_threshold() const;
+  constexpr static std::optional<std::size_t>
+      k_warn_override_threshold_default = std::nullopt;
+  void set_k_warn_override_threshold(std::size_t k_warn_override_threshold);
 
   /**
    * Maximum height of a taint (source or sink) tree after widening.
    *
    * When reaching the maximum, we collapse the leaves to reduce the height.
+   * This parameter cannot be set a runtime, as it used at compile time.
    */
   constexpr static std::size_t kSourceSinkTreeWideningHeight = 4;
 
   /**
    * Maximum size of the port of a generation.
    */
-  constexpr static std::size_t kGenerationMaxPortSize = 4;
+  std::size_t k_generation_max_port_size() const;
+  constexpr static std::size_t k_generation_max_port_size_default = 4;
+  void set_k_generation_max_port_size(std::size_t k_generation_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of output paths of generations.
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
-  constexpr static std::size_t kGenerationMaxOutputPathLeaves = 20;
+  std::size_t k_generation_max_output_path_leaves() const;
+  constexpr static std::size_t k_generation_max_output_path_leaves_default = 20;
+  void set_k_generation_max_output_path_leaves(
+      std::size_t k_generation_max_output_path_leaves);
 
   /**
    * Maximum size of the port of a parameter source.
    */
-  constexpr static std::size_t kParameterSourceMaxPortSize = 4;
+  std::size_t k_parameter_source_max_port_size() const;
+  constexpr static std::size_t k_parameter_source_max_port_size_default = 4;
+  void set_k_parameter_source_max_port_size(
+      std::size_t k_parameter_source_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of output paths of parameter sources.
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
-  constexpr static std::size_t kParameterSourceMaxOutputPathLeaves = 20;
+  std::size_t k_parameter_source_max_output_path_leaves() const;
+  constexpr static std::size_t
+      k_parameter_source_max_output_path_leaves_default = 20;
+  void set_k_parameter_source_max_output_path_leaves(
+      std::size_t k_parameter_source_max_output_path_leaves);
 
   /**
    * Maximum size of the port of a sink.
    */
-  constexpr static std::size_t kSinkMaxPortSize = 4;
+  std::size_t k_sink_max_port_size() const;
+  constexpr static std::size_t k_sink_max_port_size_default = 4;
+  void set_k_sink_max_port_size(std::size_t k_sink_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of input paths of sinks.
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
-  constexpr static std::size_t kSinkMaxInputPathLeaves = 20;
+  std::size_t k_sink_max_input_path_leaves() const;
+  constexpr static std::size_t k_sink_max_input_path_leaves_default = 20;
+  void
+  set_k_sink_max_input_path_leaves(std::size_t k_sink_max_input_path_leaves);
 
   /**
    * Maximum size of the port of a call effect source.
    */
-  constexpr static std::size_t kCallEffectSourceMaxPortSize = 4;
+  std::size_t k_call_effect_source_max_port_size() const;
+  constexpr static std::size_t k_call_effect_source_max_port_size_default = 4;
+  void set_k_call_effect_source_max_port_size(
+      std::size_t k_call_effect_source_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of output paths of call effect
@@ -88,44 +157,69 @@ class Heuristics {
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
-  constexpr static std::size_t kCallEffectSourceMaxOutputPathLeaves = 20;
+  std::size_t k_call_effect_source_max_output_path_leaves() const;
+  constexpr static std::size_t
+      k_call_effect_source_max_output_path_leaves_default = 20;
+  void set_k_call_effect_source_max_output_path_leaves(
+      std::size_t k_call_effect_source_max_output_path_leaves);
 
   /**
    * Maximum size of the port of a call effect sink.
    */
-  constexpr static std::size_t kCallEffectSinkMaxPortSize = 4;
+  std::size_t k_call_effect_sink_max_port_size() const;
+  constexpr static std::size_t k_call_effect_sink_max_port_size_default = 4;
+  void set_k_call_effect_sink_max_port_size(
+      std::size_t k_call_effect_sink_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of input paths of call effect sinks.
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
-  constexpr static std::size_t kCallEffectSinkMaxInputPathLeaves = 20;
+  std::size_t k_call_effect_sink_max_input_path_leaves() const;
+  constexpr static std::size_t
+      k_call_effect_sink_max_input_path_leaves_default = 20;
+  void set_k_call_effect_sink_max_input_path_leaves(
+      std::size_t k_call_effect_sink_max_input_path_leaves);
 
   /**
-   * Maximum number of global iterations before we abort.
+   * Maximum number of global iterations before we abort the analysis.
    */
-  constexpr static std::size_t kMaxNumberIterations = 150;
+  std::size_t k_max_number_iterations() const;
+  constexpr static std::size_t k_max_number_iterations_default = 150;
+  void set_k_max_number_iterations(std::size_t k_max_number_iterations);
 
   /**
    * Maximum number of local positions per frame.
+   *
+   * This parameter cannot be set a runtime, as it used at compile time.
    */
   constexpr static std::size_t kMaxNumberLocalPositions = 20;
 
   /**
    * Maximum depth of dependency graph traversal to find class properties.
    */
-  constexpr static std::size_t kMaxDepthClassProperties = 10;
+  std::size_t k_max_depth_class_properties() const;
+  constexpr static std::size_t k_max_depth_class_properties_default = 10;
+  void
+  set_k_max_depth_class_properties(std::size_t k_max_depth_class_properties);
 
   /**
    * Maximum number of hops that can be tracked for a call chain issue.
    */
-  constexpr static std::size_t kMaxCallChainSourceSinkDistance = 10;
+  std::size_t k_max_call_chain_source_sink_distance() const;
+  constexpr static std::size_t k_max_call_chain_source_sink_distance_default =
+      10;
+  void set_k_max_call_chain_source_sink_distance(
+      std::size_t k_max_call_chain_source_sink_distance);
 
   /**
    * Maximum size of the input access path of a propagation.
    */
-  constexpr static std::size_t kPropagationMaxInputPathSize = 4;
+  std::size_t k_propagation_max_input_path_size() const;
+  constexpr static std::size_t k_propagation_max_input_path_size_default = 4;
+  void set_k_propagation_max_input_path_size(
+      std::size_t k_propagation_max_input_path_size);
 
   /**
    * Maximum size of the output access path of a propagation.
@@ -135,7 +229,10 @@ class Heuristics {
   /**
    * Maximum number of leaves in the tree of input paths of propagations.
    */
-  constexpr static std::size_t kPropagationMaxInputPathLeaves = 4;
+  std::size_t k_propagation_max_input_path_leaves() const;
+  constexpr static std::size_t k_propagation_max_input_path_leaves_default = 4;
+  void set_k_propagation_max_input_path_leaves(
+      std::size_t k_propagation_max_input_path_leaves);
 
   /**
    * Maximum number of leaves in the tree of output paths of propagations.
@@ -146,6 +243,7 @@ class Heuristics {
    * Maximum height of the output path tree of propagations after widening.
    *
    * When reaching the maximum, we collapse the leaves to reduce the height.
+   * This parameter cannot be set a runtime, as it used at compile time.
    */
   constexpr static std::size_t kPropagationOutputPathTreeWideningHeight = 4;
 
@@ -155,6 +253,26 @@ class Heuristics {
    * This is also the maximum collapse depth for inferred propagations.
    */
   constexpr static std::uint32_t kPropagationMaxCollapseDepth = 4;
+
+private:
+  std::size_t k_join_override_threshold_;
+  std::size_t k_android_join_override_threshold_;
+  std::optional<std::size_t> k_warn_override_threshold_;
+  std::size_t k_generation_max_port_size_;
+  std::size_t k_generation_max_output_path_leaves_;
+  std::size_t k_parameter_source_max_port_size_;
+  std::size_t k_parameter_source_max_output_path_leaves_;
+  std::size_t k_sink_max_port_size_;
+  std::size_t k_sink_max_input_path_leaves_;
+  std::size_t k_call_effect_source_max_port_size_;
+  std::size_t k_call_effect_source_max_output_path_leaves_;
+  std::size_t k_call_effect_sink_max_port_size_;
+  std::size_t k_call_effect_sink_max_input_path_leaves_;
+  std::size_t k_max_number_iterations_;
+  std::size_t k_max_depth_class_properties_;
+  std::size_t k_max_call_chain_source_sink_distance_;
+  std::size_t k_propagation_max_input_path_size_;
+  std::size_t k_propagation_max_input_path_leaves_;
 };
 
 } // namespace marianatrench

--- a/source/Heuristics.h
+++ b/source/Heuristics.h
@@ -60,7 +60,6 @@ public:
    */
   std::size_t join_override_threshold() const;
   constexpr static std::size_t join_override_threshold_default = 40;
-  void set_join_override_threshold(std::size_t join_override_threshold);
 
   /**
    * When an android/java/google method has a set of overrides and greater than
@@ -68,8 +67,6 @@ public:
    */
   std::size_t android_join_override_threshold() const;
   constexpr static std::size_t android_join_override_threshold_default = 10;
-  void set_android_join_override_threshold(
-      std::size_t android_join_override_threshold);
 
   /**
    * When a method which has a set of overrides greater than this threshold that
@@ -79,8 +76,6 @@ public:
   const std::optional<std::size_t> warn_override_threshold() const;
   constexpr static std::optional<std::size_t> warn_override_threshold_default =
       std::nullopt;
-  void set_warn_override_threshold(std::size_t warn_override_threshold);
-
   /**
    * Maximum height of a taint (source or sink) tree after widening.
    *
@@ -94,8 +89,6 @@ public:
    */
   std::size_t generation_max_port_size() const;
   constexpr static std::size_t generation_max_port_size_default = 4;
-  void set_generation_max_port_size(std::size_t generation_max_port_size);
-
   /**
    * Maximum number of leaves in the tree of output paths of generations.
    *
@@ -103,16 +96,12 @@ public:
    */
   std::size_t generation_max_output_path_leaves() const;
   constexpr static std::size_t generation_max_output_path_leaves_default = 20;
-  void set_generation_max_output_path_leaves(
-      std::size_t generation_max_output_path_leaves);
 
   /**
    * Maximum size of the port of a parameter source.
    */
   std::size_t parameter_source_max_port_size() const;
   constexpr static std::size_t parameter_source_max_port_size_default = 4;
-  void set_parameter_source_max_port_size(
-      std::size_t parameter_source_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of output paths of parameter sources.
@@ -122,15 +111,12 @@ public:
   std::size_t parameter_source_max_output_path_leaves() const;
   constexpr static std::size_t parameter_source_max_output_path_leaves_default =
       20;
-  void set_parameter_source_max_output_path_leaves(
-      std::size_t parameter_source_max_output_path_leaves);
 
   /**
    * Maximum size of the port of a sink.
    */
   std::size_t sink_max_port_size() const;
   constexpr static std::size_t sink_max_port_size_default = 4;
-  void set_sink_max_port_size(std::size_t sink_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of input paths of sinks.
@@ -139,15 +125,12 @@ public:
    */
   std::size_t sink_max_input_path_leaves() const;
   constexpr static std::size_t sink_max_input_path_leaves_default = 20;
-  void set_sink_max_input_path_leaves(std::size_t sink_max_input_path_leaves);
 
   /**
    * Maximum size of the port of a call effect source.
    */
   std::size_t call_effect_source_max_port_size() const;
   constexpr static std::size_t call_effect_source_max_port_size_default = 4;
-  void set_call_effect_source_max_port_size(
-      std::size_t call_effect_source_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of output paths of call effect
@@ -158,16 +141,12 @@ public:
   std::size_t call_effect_source_max_output_path_leaves() const;
   constexpr static std::size_t
       call_effect_source_max_output_path_leaves_default = 20;
-  void set_call_effect_source_max_output_path_leaves(
-      std::size_t call_effect_source_max_output_path_leaves);
 
   /**
    * Maximum size of the port of a call effect sink.
    */
   std::size_t call_effect_sink_max_port_size() const;
   constexpr static std::size_t call_effect_sink_max_port_size_default = 4;
-  void set_call_effect_sink_max_port_size(
-      std::size_t call_effect_sink_max_port_size);
 
   /**
    * Maximum number of leaves in the tree of input paths of call effect sinks.
@@ -177,15 +156,12 @@ public:
   std::size_t call_effect_sink_max_input_path_leaves() const;
   constexpr static std::size_t call_effect_sink_max_input_path_leaves_default =
       20;
-  void set_call_effect_sink_max_input_path_leaves(
-      std::size_t call_effect_sink_max_input_path_leaves);
 
   /**
    * Maximum number of global iterations before we abort the analysis.
    */
   std::size_t max_number_iterations() const;
   constexpr static std::size_t max_number_iterations_default = 150;
-  void set_max_number_iterations(std::size_t max_number_iterations);
 
   /**
    * Maximum number of local positions per frame.
@@ -199,23 +175,18 @@ public:
    */
   std::size_t max_depth_class_properties() const;
   constexpr static std::size_t max_depth_class_properties_default = 10;
-  void set_max_depth_class_properties(std::size_t max_depth_class_properties);
 
   /**
    * Maximum number of hops that can be tracked for a call chain issue.
    */
   std::size_t max_call_chain_source_sink_distance() const;
   constexpr static std::size_t max_call_chain_source_sink_distance_default = 10;
-  void set_max_call_chain_source_sink_distance(
-      std::size_t max_call_chain_source_sink_distance);
 
   /**
    * Maximum size of the input access path of a propagation.
    */
   std::size_t propagation_max_input_path_size() const;
   constexpr static std::size_t propagation_max_input_path_size_default = 4;
-  void set_propagation_max_input_path_size(
-      std::size_t propagation_max_input_path_size);
 
   /**
    * Maximum size of the output access path of a propagation.
@@ -227,8 +198,6 @@ public:
    */
   std::size_t propagation_max_input_path_leaves() const;
   constexpr static std::size_t propagation_max_input_path_leaves_default = 4;
-  void set_propagation_max_input_path_leaves(
-      std::size_t propagation_max_input_path_leaves);
 
   /**
    * Maximum number of leaves in the tree of output paths of propagations.

--- a/source/Heuristics.h
+++ b/source/Heuristics.h
@@ -16,39 +16,7 @@ namespace marianatrench {
 
 class Heuristics final {
 public:
-  explicit Heuristics(
-      std::size_t join_override_threshold = join_override_threshold_default,
-      std::size_t android_join_override_threshold =
-          android_join_override_threshold_default,
-      std::optional<std::size_t> warn_override_threshold =
-          warn_override_threshold_default,
-      std::size_t generation_max_port_size = generation_max_port_size_default,
-      std::size_t generation_max_output_path_leaves =
-          generation_max_output_path_leaves_default,
-      std::size_t parameter_source_max_port_size =
-          parameter_source_max_port_size_default,
-      std::size_t parameter_source_max_output_path_leaves =
-          parameter_source_max_output_path_leaves_default,
-      std::size_t sink_max_port_size = sink_max_port_size_default,
-      std::size_t sink_max_input_path_leaves =
-          sink_max_input_path_leaves_default,
-      std::size_t call_effect_source_max_port_size =
-          call_effect_source_max_port_size_default,
-      std::size_t call_effect_source_max_output_path_leaves =
-          call_effect_source_max_output_path_leaves_default,
-      std::size_t call_effect_sink_max_port_size =
-          call_effect_sink_max_port_size_default,
-      std::size_t call_effect_sink_max_input_path_leaves =
-          call_effect_sink_max_input_path_leaves_default,
-      std::size_t max_number_iterations = max_number_iterations_default,
-      std::size_t max_depth_class_properties =
-          max_depth_class_properties_default,
-      std::size_t max_call_chain_source_sink_distance =
-          max_call_chain_source_sink_distance_default,
-      std::size_t propagation_max_input_path_size =
-          propagation_max_input_path_size_default,
-      std::size_t propagation_max_input_path_leaves =
-          propagation_max_input_path_leaves_default);
+  explicit Heuristics();
 
   bool operator==(const Heuristics &other) const;
 
@@ -59,14 +27,12 @@ public:
    * join all overrides at call sites.
    */
   std::size_t join_override_threshold() const;
-  constexpr static std::size_t join_override_threshold_default = 40;
 
   /**
    * When an android/java/google method has a set of overrides and greater than
    * this threshold, we do not join all overrides at call sites.
    */
   std::size_t android_join_override_threshold() const;
-  constexpr static std::size_t android_join_override_threshold_default = 10;
 
   /**
    * When a method which has a set of overrides greater than this threshold that
@@ -74,8 +40,7 @@ public:
    * print a warning.
    */
   const std::optional<std::size_t> warn_override_threshold() const;
-  constexpr static std::optional<std::size_t> warn_override_threshold_default =
-      std::nullopt;
+
   /**
    * Maximum height of a taint (source or sink) tree after widening.
    *
@@ -88,20 +53,18 @@ public:
    * Maximum size of the port of a generation.
    */
   std::size_t generation_max_port_size() const;
-  constexpr static std::size_t generation_max_port_size_default = 4;
+
   /**
    * Maximum number of leaves in the tree of output paths of generations.
    *
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
   std::size_t generation_max_output_path_leaves() const;
-  constexpr static std::size_t generation_max_output_path_leaves_default = 20;
 
   /**
    * Maximum size of the port of a parameter source.
    */
   std::size_t parameter_source_max_port_size() const;
-  constexpr static std::size_t parameter_source_max_port_size_default = 4;
 
   /**
    * Maximum number of leaves in the tree of output paths of parameter sources.
@@ -109,14 +72,11 @@ public:
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
   std::size_t parameter_source_max_output_path_leaves() const;
-  constexpr static std::size_t parameter_source_max_output_path_leaves_default =
-      20;
 
   /**
    * Maximum size of the port of a sink.
    */
   std::size_t sink_max_port_size() const;
-  constexpr static std::size_t sink_max_port_size_default = 4;
 
   /**
    * Maximum number of leaves in the tree of input paths of sinks.
@@ -124,13 +84,11 @@ public:
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
   std::size_t sink_max_input_path_leaves() const;
-  constexpr static std::size_t sink_max_input_path_leaves_default = 20;
 
   /**
    * Maximum size of the port of a call effect source.
    */
   std::size_t call_effect_source_max_port_size() const;
-  constexpr static std::size_t call_effect_source_max_port_size_default = 4;
 
   /**
    * Maximum number of leaves in the tree of output paths of call effect
@@ -139,14 +97,11 @@ public:
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
   std::size_t call_effect_source_max_output_path_leaves() const;
-  constexpr static std::size_t
-      call_effect_source_max_output_path_leaves_default = 20;
 
   /**
    * Maximum size of the port of a call effect sink.
    */
   std::size_t call_effect_sink_max_port_size() const;
-  constexpr static std::size_t call_effect_sink_max_port_size_default = 4;
 
   /**
    * Maximum number of leaves in the tree of input paths of call effect sinks.
@@ -154,14 +109,11 @@ public:
    * When reaching the maximum, we collapse all the subtrees into a single node.
    */
   std::size_t call_effect_sink_max_input_path_leaves() const;
-  constexpr static std::size_t call_effect_sink_max_input_path_leaves_default =
-      20;
 
   /**
    * Maximum number of global iterations before we abort the analysis.
    */
   std::size_t max_number_iterations() const;
-  constexpr static std::size_t max_number_iterations_default = 150;
 
   /**
    * Maximum number of local positions per frame.
@@ -174,19 +126,16 @@ public:
    * Maximum depth of dependency graph traversal to find class properties.
    */
   std::size_t max_depth_class_properties() const;
-  constexpr static std::size_t max_depth_class_properties_default = 10;
 
   /**
    * Maximum number of hops that can be tracked for a call chain issue.
    */
   std::size_t max_call_chain_source_sink_distance() const;
-  constexpr static std::size_t max_call_chain_source_sink_distance_default = 10;
 
   /**
    * Maximum size of the input access path of a propagation.
    */
   std::size_t propagation_max_input_path_size() const;
-  constexpr static std::size_t propagation_max_input_path_size_default = 4;
 
   /**
    * Maximum size of the output access path of a propagation.
@@ -197,7 +146,6 @@ public:
    * Maximum number of leaves in the tree of input paths of propagations.
    */
   std::size_t propagation_max_input_path_leaves() const;
-  constexpr static std::size_t propagation_max_input_path_leaves_default = 4;
 
   /**
    * Maximum number of leaves in the tree of output paths of propagations.

--- a/source/Interprocedural.cpp
+++ b/source/Interprocedural.cpp
@@ -196,7 +196,7 @@ void Interprocedural::run_analysis(Context& context, Registry& registry) {
         methods_to_analyze->size(),
         resident_set_size);
 
-    if (iteration > context.options->heuristics().k_max_number_iterations()) {
+    if (iteration > context.options->heuristics().max_number_iterations()) {
       ERROR(1, "Too many iterations");
       std::string message = "Unstable methods are:";
       for (const auto* method : *methods_to_analyze) {

--- a/source/Interprocedural.cpp
+++ b/source/Interprocedural.cpp
@@ -138,7 +138,8 @@ Model analyze(
   new_model.approximate(/* widening_features */
                         FeatureMayAlwaysSet{
                             global_context.feature_factory
-                                ->get_widen_broadening_feature()});
+                                ->get_widen_broadening_feature()},
+                        global_context.options->heuristics());
 
   LOG_OR_DUMP(
       &method_context,
@@ -195,7 +196,7 @@ void Interprocedural::run_analysis(Context& context, Registry& registry) {
         methods_to_analyze->size(),
         resident_set_size);
 
-    if (iteration > Heuristics::kMaxNumberIterations) {
+    if (iteration > context.options->heuristics().k_max_number_iterations()) {
       ERROR(1, "Too many iterations");
       std::string message = "Unstable methods are:";
       for (const auto* method : *methods_to_analyze) {

--- a/source/JsonValidation.cpp
+++ b/source/JsonValidation.cpp
@@ -129,6 +129,18 @@ uint32_t JsonValidation::unsigned_integer(const Json::Value& value) {
   return value.asUInt();
 }
 
+uint32_t JsonValidation::unsigned_integer(
+    const Json::Value& value,
+    const std::string& field) {
+  validate_object(
+      value, fmt::format("non-null object with unsigned integer field `{}`", field));
+  const auto& integer = value[field];
+  if (integer.isNull() || !integer.isUInt()) {
+    throw JsonValidationError(value, field, /* expected */ "unsigned integer");
+  }
+  return integer.asUInt();
+}
+
 bool JsonValidation::boolean(const Json::Value& value) {
   if (value.isNull() || !value.isBool()) {
     throw JsonValidationError(
@@ -216,6 +228,13 @@ const Json::Value& JsonValidation::object_or_string(
     throw JsonValidationError(value, field, /* expected */ "object or string");
   }
   return attribute;
+}
+
+bool JsonValidation::has_field(
+    const Json::Value& value,
+    const std::string& field) {
+  const auto& attribute = value[field];
+  return !attribute.isNull();
 }
 
 void JsonValidation::update_object(

--- a/source/JsonValidation.h
+++ b/source/JsonValidation.h
@@ -48,6 +48,9 @@ class JsonValidation final {
       const std::string& field);
 
   static uint32_t unsigned_integer(const Json::Value& value);
+  static uint32_t unsigned_integer(
+      const Json::Value& value,
+      const std::string& field);
 
   static bool boolean(const Json::Value& value);
   static bool boolean(const Json::Value& value, const std::string& field);
@@ -69,6 +72,10 @@ class JsonValidation final {
   static const Json::Value& object_or_string(
       const Json::Value& value,
       const std::string& field);
+
+  static bool has_field(
+    const Json::Value& value,
+    const std::string& field);
 
   /**
    * Add (key, value) pairs from the given `right` object into the given `left`

--- a/source/MethodContext.cpp
+++ b/source/MethodContext.cpp
@@ -125,7 +125,8 @@ Model MethodContext::model_at_callsite(
   }
 
   model.approximate(
-      FeatureMayAlwaysSet{feature_factory.get_widen_broadening_feature()});
+      FeatureMayAlwaysSet{feature_factory.get_widen_broadening_feature()},
+      context_.options->heuristics());
 
   callsite_model_cache_.emplace(CacheKey{call_target, position}, model);
   return model;

--- a/source/Model.cpp
+++ b/source/Model.cpp
@@ -189,19 +189,19 @@ Model::Model(
   }
 
   for (const auto& [port, source] : generations) {
-    add_generation(port, source);
+    add_generation(port, source, context.options->heuristics());
   }
 
   for (const auto& [port, source] : parameter_sources) {
-    add_parameter_source(port, source);
+    add_parameter_source(port, source, context.options->heuristics());
   }
 
   for (const auto& [port, sink] : sinks) {
-    add_sink(port, sink);
+    add_sink(port, sink, context.options->heuristics());
   }
 
   for (const auto& propagation : propagations) {
-    add_propagation(propagation);
+    add_propagation(propagation, context.options->heuristics());
   }
 
   for (const auto& sanitizer : global_sanitizers) {
@@ -268,28 +268,28 @@ Model Model::instantiate(const Method* method, Context& context) const {
   Model model(method, context, modes_, frozen_);
 
   for (const auto& [port, generation_taint] : generations_.elements()) {
-    model.add_generation(port, generation_taint);
+    model.add_generation(port, generation_taint, context.options->heuristics());
   }
 
   for (const auto& [port, parameter_source_taint] :
        parameter_sources_.elements()) {
-    model.add_parameter_source(port, parameter_source_taint);
+    model.add_parameter_source(port, parameter_source_taint, context.options->heuristics());
   }
 
   for (const auto& [port, sink_taint] : sinks_.elements()) {
-    model.add_sink(port, sink_taint);
+    model.add_sink(port, sink_taint, context.options->heuristics());
   }
 
   for (const auto& [port, source_taint] : call_effect_sources_.elements()) {
-    model.add_call_effect_source(port, source_taint);
+    model.add_call_effect_source(port, source_taint, context.options->heuristics());
   }
 
   for (const auto& [port, sink_taint] : call_effect_sinks_.elements()) {
-    model.add_call_effect_sink(port, sink_taint);
+    model.add_call_effect_sink(port, sink_taint, context.options->heuristics());
   }
 
   for (const auto& [input_path, output] : propagations_.elements()) {
-    model.add_propagation(input_path, output);
+    model.add_propagation(input_path, output, context.options->heuristics());
   }
 
   for (const auto& sanitizer : global_sanitizers_) {
@@ -453,13 +453,16 @@ Model Model::at_callsite(
         UpdateKind::Weak);
   });
 
+  std::size_t k_max_call_chain_source_sink_distance =
+    context.options->heuristics().k_max_call_chain_source_sink_distance();
   call_effect_sinks_.visit(
       [&model,
        callee,
        call_position,
        &context,
        &narrowed_class_interval_context,
-       &caller_class_interval](
+       &caller_class_interval,
+       k_max_call_chain_source_sink_distance](
           const AccessPath& callee_port, const Taint& call_effect) {
         switch (callee_port.root().kind()) {
           case Root::Kind::CallEffectCallChain:
@@ -470,7 +473,7 @@ Model Model::at_callsite(
                     callee,
                     context.access_path_factory->get(callee_port),
                     call_position,
-                    Heuristics::kMaxCallChainSourceSinkDistance,
+                    k_max_call_chain_source_sink_distance,
                     context,
                     /* source register types */ {},
                     /* source constant arguments */ {},
@@ -611,31 +614,34 @@ void Model::collapse_invalid_paths(Context& context) {
       is_valid, initial_accumulator, features);
 }
 
-void Model::approximate(const FeatureMayAlwaysSet& widening_features) {
+void Model::approximate(
+    const FeatureMayAlwaysSet& widening_features,
+    const Heuristics& heuristics) {
   const auto make_mold = [](Taint taint) { return taint.essential(); };
 
   generations_.shape_with(make_mold, widening_features);
   generations_.limit_leaves(
-      Heuristics::kGenerationMaxOutputPathLeaves, widening_features);
+      heuristics.k_generation_max_output_path_leaves(), widening_features);
 
   parameter_sources_.shape_with(make_mold, widening_features);
   parameter_sources_.limit_leaves(
-      Heuristics::kParameterSourceMaxOutputPathLeaves, widening_features);
+      heuristics.k_parameter_source_max_output_path_leaves(), widening_features);
 
   sinks_.shape_with(make_mold, widening_features);
-  sinks_.limit_leaves(Heuristics::kSinkMaxInputPathLeaves, widening_features);
+  sinks_.limit_leaves(
+    heuristics.k_sink_max_input_path_leaves(), widening_features);
 
   call_effect_sources_.shape_with(make_mold, widening_features);
   call_effect_sources_.limit_leaves(
-      Heuristics::kCallEffectSourceMaxOutputPathLeaves, widening_features);
+      heuristics.k_call_effect_source_max_output_path_leaves(), widening_features);
 
   call_effect_sinks_.shape_with(make_mold, widening_features);
   call_effect_sinks_.limit_leaves(
-      Heuristics::kCallEffectSinkMaxInputPathLeaves, widening_features);
+      heuristics.k_call_effect_sink_max_input_path_leaves(), widening_features);
 
   propagations_.shape_with(make_mold, widening_features);
   propagations_.limit_leaves(
-      Heuristics::kPropagationMaxInputPathLeaves, widening_features);
+      heuristics.k_propagation_max_input_path_leaves(), widening_features);
 }
 
 bool Model::empty() const {
@@ -778,114 +784,136 @@ void Model::add_taint_in_taint_this(Context& context) {
         PathTreeDomain{{Path{}, CollapseDepth::zero()}},
         /* inferred_features */ FeatureMayAlwaysSet::bottom(),
         /* locally_inferred_features */ FeatureMayAlwaysSet::bottom(),
-        user_features));
+        user_features),
+        context.options->heuristics());
   }
 }
 
-void Model::add_generation(const AccessPath& port, TaintConfig source) {
+void Model::add_generation(const AccessPath& port, TaintConfig source, const Heuristics& heuristics) {
   if (!check_taint_config_consistency(source, "source")) {
     return;
   }
-  add_generation(port, Taint{std::move(source)});
+  add_generation(port, Taint{std::move(source)}, heuristics);
 }
 
 void Model::add_inferred_generations(
     AccessPath port,
     Taint generations,
-    const FeatureMayAlwaysSet& widening_features) {
+    const FeatureMayAlwaysSet& widening_features,
+    const Heuristics& heuristics) {
   auto sanitized_generations = apply_source_sink_sanitizers(
       SanitizerKind::Sources, std::move(generations), port.root());
   if (!sanitized_generations.is_bottom()) {
     update_taint_tree(
         generations_,
         std::move(port),
-        Heuristics::kGenerationMaxPortSize,
+        heuristics.k_generation_max_port_size(),
         std::move(sanitized_generations),
         widening_features);
   }
 }
 
-void Model::add_parameter_source(const AccessPath& port, TaintConfig source) {
+void Model::add_parameter_source(
+    const AccessPath& port,
+    TaintConfig source,
+    const Heuristics& heuristics) {
   if (!check_taint_config_consistency(source, "source")) {
     return;
   }
 
-  add_parameter_source(port, Taint{std::move(source)});
+  add_parameter_source(port, Taint{std::move(source)}, heuristics);
 }
 
-void Model::add_sink(const AccessPath& port, TaintConfig sink) {
+void Model::add_sink(
+    const AccessPath& port,
+    TaintConfig sink,
+    const Heuristics& heuristics) {
   if (!check_taint_config_consistency(sink, "sink")) {
     return;
   }
 
-  add_sink(port, Taint{std::move(sink)});
+  add_sink(port, Taint{std::move(sink)}, heuristics);
 }
 
 void Model::add_inferred_sinks(
     AccessPath port,
     Taint sinks,
-    const FeatureMayAlwaysSet& widening_features) {
+    const FeatureMayAlwaysSet& widening_features,
+    const Heuristics& heuristics) {
   auto sanitized_sinks = apply_source_sink_sanitizers(
       SanitizerKind::Sinks, std::move(sinks), port.root());
   if (!sanitized_sinks.is_bottom()) {
     update_taint_tree(
         sinks_,
         std::move(port),
-        Heuristics::kSinkMaxPortSize,
+        heuristics.k_sink_max_port_size(),
         std::move(sanitized_sinks),
         widening_features);
   }
 }
 
-void Model::add_call_effect_source(AccessPath port, TaintConfig source) {
+void Model::add_call_effect_source(
+    AccessPath port,
+    TaintConfig source,
+    const Heuristics& heuristics) {
   if (!check_taint_config_consistency(source, "effect source")) {
     return;
   }
 
-  add_call_effect_source(port, Taint{std::move(source)});
+  add_call_effect_source(port, Taint{std::move(source)}, heuristics);
 }
 
-void Model::add_call_effect_sink(AccessPath port, TaintConfig sink) {
+void Model::add_call_effect_sink(
+    AccessPath port,
+    TaintConfig sink,
+    const Heuristics& heuristics) {
   if (!check_taint_config_consistency(sink, "effect sink")) {
     return;
   }
 
-  add_call_effect_sink(port, Taint{std::move(sink)});
-}
-
-void Model::add_inferred_call_effect_sinks(AccessPath port, Taint sinks) {
-  add_call_effect_sink(port, sinks);
+  add_call_effect_sink(port, Taint{std::move(sink)}, heuristics);
 }
 
 void Model::add_inferred_call_effect_sinks(
     AccessPath port,
     Taint sinks,
-    const FeatureMayAlwaysSet& widening_features) {
+    const Heuristics& heuristics) {
+  add_call_effect_sink(port, sinks, heuristics);
+}
+
+void Model::add_inferred_call_effect_sinks(
+    AccessPath port,
+    Taint sinks,
+    const FeatureMayAlwaysSet& widening_features,
+    const Heuristics& heuristics) {
   auto sanitized_sinks = apply_source_sink_sanitizers(
       SanitizerKind::Sinks, std::move(sinks), port.root());
   if (!sanitized_sinks.is_bottom()) {
     update_taint_tree(
         call_effect_sinks_,
         std::move(port),
-        Heuristics::kCallEffectSinkMaxPortSize,
+        heuristics.k_call_effect_sink_max_port_size(),
         std::move(sanitized_sinks),
         widening_features);
   }
 }
 
-void Model::add_propagation(PropagationConfig propagation) {
+void Model::add_propagation(
+    PropagationConfig propagation,
+    const Heuristics& heuristics) {
   if (!check_port_consistency(propagation.input_path()) ||
       !check_root_consistency(propagation.propagation_kind()->root())) {
     return;
   }
 
-  add_propagation(propagation.input_path(), Taint::propagation(propagation));
+  add_propagation(propagation.input_path(), Taint::propagation(propagation), heuristics);
 }
 
 void Model::add_inferred_propagations(
     AccessPath input_path,
     Taint local_taint,
-    const FeatureMayAlwaysSet& widening_features) {
+    const FeatureMayAlwaysSet& widening_features,
+    const Heuristics& heuristics) {
   if (has_global_propagation_sanitizer() ||
       !port_sanitizers_.get(input_path.root()).is_bottom()) {
     return;
@@ -894,7 +922,7 @@ void Model::add_inferred_propagations(
   update_taint_tree(
       propagations_,
       std::move(input_path),
-      Heuristics::kPropagationMaxInputPathSize,
+      heuristics.k_propagation_max_input_path_size(),
       std::move(local_taint),
       widening_features);
 }
@@ -1327,17 +1355,23 @@ Model Model::from_config_json(
       TaintConfigTemplate::is_concrete);
 
   for (const auto& [port, generation_value] : generation_values) {
-    model.add_generation(
-        port, TaintConfig::from_json(generation_value, context));
+    model.add_generation(port,
+        TaintConfig::from_json(generation_value, context),
+        context.options->heuristics());
   }
 
   for (const auto& [port, parameter_source_value] : parameter_source_values) {
     model.add_parameter_source(
-        port, TaintConfig::from_json(parameter_source_value, context));
+        port,
+        TaintConfig::from_json(parameter_source_value, context),
+        context.options->heuristics());
   }
 
   for (const auto& [port, sink_value] : sink_values) {
-    model.add_sink(port, TaintConfig::from_json(sink_value, context));
+    model.add_sink(
+        port,
+        TaintConfig::from_json(sink_value, context),
+        context.options->heuristics());
   }
 
   for (auto effect_source_value :
@@ -1347,7 +1381,9 @@ Model Model::from_config_json(
     JsonValidation::string(effect_source_value, /* field */ effect_type_port);
     auto port = AccessPath::from_json(effect_source_value[effect_type_port]);
     model.add_call_effect_source(
-        port, TaintConfig::from_json(effect_source_value, context));
+        port,
+        TaintConfig::from_json(effect_source_value, context),
+        context.options->heuristics());
   }
 
   for (auto effect_sink_value :
@@ -1357,13 +1393,16 @@ Model Model::from_config_json(
     JsonValidation::string(effect_sink_value, /* field */ effect_type_port);
     auto port = AccessPath::from_json(effect_sink_value[effect_type_port]);
     model.add_call_effect_sink(
-        port, TaintConfig::from_json(effect_sink_value, context));
+        port,
+        TaintConfig::from_json(effect_sink_value, context),
+        context.options->heuristics());
   }
 
   for (auto propagation_value :
        JsonValidation::null_or_array(value, /* field */ "propagation")) {
     model.add_propagation(
-        PropagationConfig::from_json(propagation_value, context));
+        PropagationConfig::from_json(propagation_value, context),
+        context.options->heuristics());
   }
 
   for (auto sanitizer_value :
@@ -1577,42 +1616,42 @@ Model Model::from_json(const Json::Value& value, Context& context) {
        JsonValidation::null_or_array(value, /* field */ "generations")) {
     auto port = AccessPath::from_json(generation_value["port"]);
     auto taint = Taint::from_json(generation_value["taint"], context);
-    model.add_generation(port, taint);
+    model.add_generation(port, taint, context.options->heuristics());
   }
 
   for (const auto& parameter_source_value :
        JsonValidation::null_or_array(value, /* field */ "parameter_sources")) {
     auto port = AccessPath::from_json(parameter_source_value["port"]);
     auto taint = Taint::from_json(parameter_source_value["taint"], context);
-    model.add_parameter_source(port, taint);
+    model.add_parameter_source(port, taint, context.options->heuristics());
   }
 
   for (const auto& call_effect_source_value :
        JsonValidation::null_or_array(value, /* field */ "effect_sources")) {
     auto port = AccessPath::from_json(call_effect_source_value["port"]);
     auto taint = Taint::from_json(call_effect_source_value["taint"], context);
-    model.add_call_effect_source(port, taint);
+    model.add_call_effect_source(port, taint, context.options->heuristics());
   }
 
   for (const auto& sink_value :
        JsonValidation::null_or_array(value, /* field */ "sinks")) {
     auto port = AccessPath::from_json(sink_value["port"]);
     auto taint = Taint::from_json(sink_value["taint"], context);
-    model.add_sink(port, taint);
+    model.add_sink(port, taint, context.options->heuristics());
   }
 
   for (const auto& call_effect_sink_value :
        JsonValidation::null_or_array(value, /* field */ "effect_sinks")) {
     auto port = AccessPath::from_json(call_effect_sink_value["port"]);
     auto taint = Taint::from_json(call_effect_sink_value["taint"], context);
-    model.add_call_effect_sink(port, taint);
+    model.add_call_effect_sink(port, taint, context.options->heuristics());
   }
 
   for (const auto& propagation_value :
        JsonValidation::null_or_array(value, /* field */ "propagation")) {
     auto input_path = AccessPath::from_json(propagation_value["input"]);
     auto output_taint = Taint::from_json(propagation_value["output"], context);
-    model.add_propagation(input_path, output_taint);
+    model.add_propagation(input_path, output_taint, context.options->heuristics());
   }
 
   for (const auto& sanitizer_value :
@@ -2254,7 +2293,10 @@ bool Model::check_call_effect_port_consistency(
   return true;
 }
 
-void Model::add_generation(AccessPath port, Taint source) {
+void Model::add_generation(
+    AccessPath port,
+    Taint source,
+    const Heuristics& heuristics) {
   if (method_) {
     source.add_origins_if_declaration(
         method_, AccessPathFactory::singleton().get(port));
@@ -2264,19 +2306,22 @@ void Model::add_generation(AccessPath port, Taint source) {
     return;
   }
 
-  if (port.path().size() > Heuristics::kGenerationMaxPortSize) {
+  if (port.path().size() > heuristics.k_generation_max_port_size()) {
     WARNING(
         1,
         "Truncating user-defined generation {} down to path length {} for method {}",
         port,
-        Heuristics::kGenerationMaxPortSize,
+        heuristics.k_generation_max_port_size(),
         method_ ? method_->get_name() : "nullptr");
   }
-  port.truncate(Heuristics::kGenerationMaxPortSize);
+  port.truncate(heuristics.k_generation_max_port_size());
   generations_.write(port, std::move(source), UpdateKind::Weak);
 }
 
-void Model::add_parameter_source(AccessPath port, Taint source) {
+void Model::add_parameter_source(
+    AccessPath port,
+    Taint source,
+    const Heuristics& heuristics) {
   if (method_) {
     source.add_origins_if_declaration(
         method_, AccessPathFactory::singleton().get(port));
@@ -2288,19 +2333,19 @@ void Model::add_parameter_source(AccessPath port, Taint source) {
     return;
   }
 
-  if (port.path().size() > Heuristics::kParameterSourceMaxPortSize) {
+  if (port.path().size() > heuristics.k_parameter_source_max_port_size()) {
     WARNING(
         1,
         "Truncating user-defined parameter source {} down to path length {} for method {}",
         port,
-        Heuristics::kParameterSourceMaxPortSize,
+        heuristics.k_parameter_source_max_port_size(),
         method_ ? method_->get_name() : "nullptr");
   }
-  port.truncate(Heuristics::kParameterSourceMaxPortSize);
+  port.truncate(heuristics.k_parameter_source_max_port_size());
   parameter_sources_.write(port, Taint{std::move(source)}, UpdateKind::Weak);
 }
 
-void Model::add_sink(AccessPath port, Taint sink) {
+void Model::add_sink(AccessPath port, Taint sink, const Heuristics& heuristics) {
   if (method_) {
     sink.add_origins_if_declaration(
         method_, AccessPathFactory::singleton().get(port));
@@ -2310,19 +2355,19 @@ void Model::add_sink(AccessPath port, Taint sink) {
     return;
   }
 
-  if (port.path().size() > Heuristics::kSinkMaxPortSize) {
+  if (port.path().size() > heuristics.k_sink_max_port_size()) {
     WARNING(
         1,
         "Truncating user-defined sink {} down to path length {} for method {}",
         port,
-        Heuristics::kSinkMaxPortSize,
+        heuristics.k_sink_max_port_size(),
         method_ ? method_->get_name() : "nullptr");
   }
-  port.truncate(Heuristics::kSinkMaxPortSize);
+  port.truncate(heuristics.k_sink_max_port_size());
   sinks_.write(port, Taint{std::move(sink)}, UpdateKind::Weak);
 }
 
-void Model::add_call_effect_source(AccessPath port, Taint source) {
+void Model::add_call_effect_source(AccessPath port, Taint source, const Heuristics& heuristics) {
   if (!check_call_effect_port_consistency(port, "effect source")) {
     return;
   }
@@ -2336,20 +2381,20 @@ void Model::add_call_effect_source(AccessPath port, Taint source) {
     return;
   }
 
-  if (port.path().size() > Heuristics::kCallEffectSourceMaxPortSize) {
+  if (port.path().size() > heuristics.k_call_effect_source_max_port_size()) {
     WARNING(
         1,
         "Truncating user-defined call effect source port {} down to path length {} for method {}",
         port,
-        Heuristics::kCallEffectSourceMaxPortSize,
+        heuristics.k_call_effect_source_max_port_size(),
         method_ ? method_->get_name() : "nullptr");
   }
 
-  port.truncate(Heuristics::kCallEffectSourceMaxPortSize);
+  port.truncate(heuristics.k_call_effect_source_max_port_size());
   call_effect_sources_.write(port, std::move(source), UpdateKind::Weak);
 }
 
-void Model::add_call_effect_sink(AccessPath port, Taint sink) {
+void Model::add_call_effect_sink(AccessPath port, Taint sink, const Heuristics& heuristics) {
   if (!check_call_effect_port_consistency(port, "effect sink")) {
     return;
   }
@@ -2363,20 +2408,23 @@ void Model::add_call_effect_sink(AccessPath port, Taint sink) {
     return;
   }
 
-  if (port.path().size() > Heuristics::kCallEffectSinkMaxPortSize) {
+  if (port.path().size() > heuristics.k_call_effect_sink_max_port_size()) {
     WARNING(
         1,
         "Truncating user-defined call effect sink port {} down to path length {} for method {}",
         port,
-        Heuristics::kCallEffectSinkMaxPortSize,
+        heuristics.k_call_effect_sink_max_port_size(),
         method_ ? method_->get_name() : "nullptr");
   }
 
-  port.truncate(Heuristics::kCallEffectSinkMaxPortSize);
+  port.truncate(heuristics.k_call_effect_sink_max_port_size());
   call_effect_sinks_.write(port, std::move(sink), UpdateKind::Weak);
 }
 
-void Model::add_propagation(AccessPath input_path, Taint output) {
+void Model::add_propagation(
+    AccessPath input_path,
+    Taint output,
+    const Heuristics& heuristics) {
   if (!check_root_consistency(input_path.root())) {
     return;
   }
@@ -2386,15 +2434,15 @@ void Model::add_propagation(AccessPath input_path, Taint output) {
         method_, AccessPathFactory::singleton().get(input_path));
   }
 
-  if (input_path.path().size() > Heuristics::kPropagationMaxInputPathSize) {
+  if (input_path.path().size() > heuristics.k_propagation_max_input_path_size()) {
     WARNING(
         1,
         "Truncating user-defined propagation {} down to path length {} for method {}",
         input_path.path(),
-        Heuristics::kPropagationMaxInputPathSize,
+        heuristics.k_propagation_max_input_path_size(),
         method_ ? method_->get_name() : "nullptr");
   }
-  input_path.truncate(Heuristics::kPropagationMaxInputPathSize);
+  input_path.truncate(heuristics.k_propagation_max_input_path_size());
   propagations_.write(input_path, output, UpdateKind::Weak);
 }
 

--- a/source/Model.cpp
+++ b/source/Model.cpp
@@ -682,7 +682,8 @@ void add_taint_in_taint_out_propagation(
   for (ParameterPosition parameter_position = 0;
        parameter_position < number_of_parameters;
        parameter_position++) {
-    model.add_propagation(PropagationConfig(
+    model.add_propagation(
+      PropagationConfig(
         /* input_path */ AccessPath(
             Root(Root::Kind::Argument, parameter_position)),
         /* kind */ context.kind_factory->local_return(),
@@ -690,7 +691,8 @@ void add_taint_in_taint_out_propagation(
         PathTreeDomain{{Path{}, CollapseDepth::zero()}},
         /* inferred_features */ FeatureMayAlwaysSet::bottom(),
         /* locally_inferred_features */ FeatureMayAlwaysSet::bottom(),
-        user_features));
+        user_features),
+      context.options->heuristics());
   }
 }
 

--- a/source/Model.h
+++ b/source/Model.h
@@ -194,7 +194,9 @@ class Model final {
 
   void collapse_invalid_paths(Context& context);
 
-  void approximate(const FeatureMayAlwaysSet& widening_features);
+  void approximate(
+      const FeatureMayAlwaysSet& widening_features,
+      const Heuristics& heuristics);
 
   bool empty() const;
 
@@ -209,13 +211,17 @@ class Model final {
 
   void add_taint_in_taint_this(Context& context);
 
-  void add_generation(const AccessPath& port, TaintConfig generation);
+  void add_generation(
+      const AccessPath& port,
+      TaintConfig generation,
+      const Heuristics& heuristics);
 
   /* Add generations after applying sanitizers */
   void add_inferred_generations(
       AccessPath port,
       Taint generations,
-      const FeatureMayAlwaysSet& widening_features);
+      const FeatureMayAlwaysSet& widening_features,
+      const Heuristics& heuristics);
   const TaintAccessPathTree& generations() const {
     return generations_;
   }
@@ -223,7 +229,10 @@ class Model final {
     generations_ = std::move(generations);
   }
 
-  void add_parameter_source(const AccessPath& port, TaintConfig source);
+  void add_parameter_source(
+      const AccessPath& port,
+      TaintConfig source,
+      const Heuristics& heuristics);
   const TaintAccessPathTree& parameter_sources() const {
     return parameter_sources_;
   }
@@ -231,13 +240,17 @@ class Model final {
     parameter_sources_ = std::move(parameter_sources);
   }
 
-  void add_sink(const AccessPath& port, TaintConfig sink);
+  void add_sink(
+      const AccessPath& port,
+      TaintConfig sink,
+      const Heuristics& heuristics);
 
   /* Add sinks after applying sanitizers */
   void add_inferred_sinks(
       AccessPath port,
       Taint sinks,
-      const FeatureMayAlwaysSet& widening_features);
+      const FeatureMayAlwaysSet& widening_features,
+      const Heuristics& heuristics);
   const TaintAccessPathTree& sinks() const {
     return sinks_;
   }
@@ -248,24 +261,37 @@ class Model final {
   const TaintAccessPathTree& call_effect_sources() const {
     return call_effect_sources_;
   }
-  void add_call_effect_source(AccessPath port, TaintConfig source);
+  void add_call_effect_source(
+      AccessPath port,
+      TaintConfig source,
+      const Heuristics& heuristics);
 
   const TaintAccessPathTree& call_effect_sinks() const {
     return call_effect_sinks_;
   }
-  void add_call_effect_sink(AccessPath port, TaintConfig sink);
-  void add_inferred_call_effect_sinks(AccessPath port, Taint sink);
+  void add_call_effect_sink(
+      AccessPath port,
+      TaintConfig sink,
+      const Heuristics& heuristics);
   void add_inferred_call_effect_sinks(
       AccessPath port,
       Taint sink,
-      const FeatureMayAlwaysSet& widening_features);
+      const Heuristics& heuristics);
+  void add_inferred_call_effect_sinks(
+      AccessPath port,
+      Taint sink,
+      const FeatureMayAlwaysSet& widening_features,
+      const Heuristics& heuristics);
 
-  void add_propagation(PropagationConfig propagation);
+  void add_propagation(
+      PropagationConfig propagation,
+      const Heuristics& heuristics);
   /* Add a propagation after applying sanitizers */
   void add_inferred_propagations(
       AccessPath input_path,
       Taint local_taint,
-      const FeatureMayAlwaysSet& widening_features);
+      const FeatureMayAlwaysSet& widening_features,
+      const Heuristics& heuristics);
   const TaintAccessPathTree& propagations() const {
     return propagations_;
   }
@@ -423,12 +449,30 @@ class Model final {
   // `Model` object. This guarantees that it was constructed using a
   // `TaintConfig` in `Model`'s constructor, and has passed other verification
   // checks in the `add_*(AccessPath, TaintConfig)` methods.
-  void add_generation(AccessPath port, Taint generation);
-  void add_parameter_source(AccessPath port, Taint source);
-  void add_sink(AccessPath port, Taint sink);
-  void add_call_effect_source(AccessPath port, Taint source);
-  void add_call_effect_sink(AccessPath port, Taint sink);
-  void add_propagation(AccessPath input_path, Taint output);
+  void add_generation(
+      AccessPath port,
+      Taint generation,
+      const Heuristics& heuristics);
+  void add_parameter_source(
+      AccessPath port,
+      Taint source,
+      const Heuristics& heuristics);
+  void add_sink(
+      AccessPath port,
+      Taint sink,
+      const Heuristics& heuristics);
+  void add_call_effect_source(
+      AccessPath port,
+      Taint source,
+      const Heuristics& heuristics);
+  void add_call_effect_sink(
+      AccessPath port,
+      Taint sink,
+      const Heuristics& heuristics);
+  void add_propagation(
+      AccessPath input_path,
+      Taint output,
+      const Heuristics& heuristics);
 
  private:
   const Method* MT_NULLABLE method_;

--- a/source/Options.cpp
+++ b/source/Options.cpp
@@ -298,9 +298,9 @@ Options::Options(const boost::program_options::variables_map& variables) {
       variables.count("propagate-across-arguments") > 0;
 
   if (!variables["heuristics"].empty()) {
-    std::string heuristics_path =
+    auto heuristics_path =
         check_path_exists(variables["heuristics"].as<std::string>()) ;
-    Json::Value json = JsonReader::parse_json_file(heuristics_path);
+    auto json = JsonReader::parse_json_file(heuristics_path);
     heuristics_ = Heuristics::from_json(json);
   }
 }

--- a/source/Options.cpp
+++ b/source/Options.cpp
@@ -113,7 +113,8 @@ Options::Options(
     const std::string& source_root_directory,
     bool enable_cross_component_analysis,
     ExportOriginsMode export_origins_mode,
-    bool propagate_across_arguments)
+    bool propagate_across_arguments,
+    const Heuristics& heuristics)
     : models_paths_(models_paths),
       field_models_paths_(field_models_paths),
       literal_models_paths_(literal_models_paths),
@@ -144,7 +145,8 @@ Options::Options(
       dump_coverage_info_(false),
       enable_cross_component_analysis_(enable_cross_component_analysis),
       export_origins_mode_(export_origins_mode),
-      propagate_across_arguments_(propagate_across_arguments) {}
+      propagate_across_arguments_(propagate_across_arguments),
+      heuristics_(heuristics) {}
 
 Options::Options(const boost::program_options::variables_map& variables) {
   system_jar_paths_ = parse_paths_list(
@@ -294,6 +296,13 @@ Options::Options(const boost::program_options::variables_map& variables) {
       : ExportOriginsMode::OnlyOnOrigins;
   propagate_across_arguments_ =
       variables.count("propagate-across-arguments") > 0;
+
+  if (!variables["heuristics"].empty()) {
+    std::string heuristics_path =
+        check_path_exists(variables["heuristics"].as<std::string>()) ;
+    Json::Value json = JsonReader::parse_json_file(heuristics_path);
+    heuristics_ = Heuristics::from_json(json);
+  }
 }
 
 void Options::add_options(
@@ -463,6 +472,10 @@ void Options::add_options(
   options.add_options()(
       "propagate-across-arguments",
       "Enable taint propagation across object type arguments. By default, taint propagation is only tracked for return values and the `this` argument. This enables taint propagation across method invocations for all other object type arguments as well.");
+  options.add_options()(
+      "heuristics",
+      program_options::value<std::string>(),
+      "Path to JSON configuration file which specifies heuristics parameters to use during the analysis. See the documentation for available heuristics parameters.");
 }
 
 const std::vector<std::string>& Options::models_paths() const {
@@ -697,6 +710,10 @@ ExportOriginsMode Options::export_origins_mode() const {
 
 bool Options::propagate_across_arguments() const {
   return propagate_across_arguments_;
+}
+
+const marianatrench::Heuristics& Options::heuristics() const {
+  return heuristics_;
 }
 
 } // namespace marianatrench

--- a/source/Options.h
+++ b/source/Options.h
@@ -16,6 +16,7 @@
 #include <json/json.h>
 
 #include <mariana-trench/ExportOriginsMode.h>
+#include <mariana-trench/Heuristics.h>
 #include <mariana-trench/IncludeMacros.h>
 #include <mariana-trench/model-generator/ModelGeneratorConfiguration.h>
 
@@ -43,7 +44,8 @@ class Options final {
       const std::string& source_root_directory = ".",
       bool enable_cross_component_analysis = false,
       ExportOriginsMode export_origins_mode = ExportOriginsMode::Always,
-      bool propagate_across_arguments = false);
+      bool propagate_across_arguments = false,
+      const Heuristics& heuristics = Heuristics());
 
   explicit Options(const boost::program_options::variables_map& variables);
 
@@ -122,6 +124,8 @@ class Options final {
   ExportOriginsMode export_origins_mode() const;
   bool propagate_across_arguments() const;
 
+  const Heuristics& heuristics() const;
+
  private:
   std::vector<std::string> models_paths_;
   std::vector<std::string> field_models_paths_;
@@ -180,6 +184,8 @@ class Options final {
   bool enable_cross_component_analysis_;
   ExportOriginsMode export_origins_mode_;
   bool propagate_across_arguments_;
+
+  Heuristics heuristics_;
 };
 
 } // namespace marianatrench

--- a/source/model-generator/ContentProviderGenerator.cpp
+++ b/source/model-generator/ContentProviderGenerator.cpp
@@ -42,7 +42,8 @@ Model create_model(
         AccessPath(Root(Root::Kind::Argument, argument.first)),
         generator::source(
             context,
-            /* kind */ "ProviderUserInput"));
+            /* kind */ "ProviderUserInput"),
+        context.options->heuristics());
   }
   auto return_type = generator::get_return_type_string(method);
   if (!return_type) {
@@ -53,7 +54,8 @@ Model create_model(
         AccessPath(Root(Root::Kind::Return)),
         generator::sink(
             context,
-            /* kind */ "ProviderExitNode"));
+            /* kind */ "ProviderExitNode"),
+        context.options->heuristics());
   }
   return model;
 }

--- a/source/model-generator/JoinOverrideGenerator.cpp
+++ b/source/model-generator/JoinOverrideGenerator.cpp
@@ -16,7 +16,7 @@ std::vector<Model> JoinOverrideGenerator::visit_method(
 
   // Do not join models at call sites for methods with too many overrides.
   const auto& overrides = context_.overrides->get(method);
-  if (overrides.size() >= options_.heuristics().k_join_override_threshold()) {
+  if (overrides.size() >= options_.heuristics().join_override_threshold()) {
     models.push_back(
         Model(method, context_, Model::Mode::NoJoinVirtualOverrides));
   } else {
@@ -25,7 +25,7 @@ std::vector<Model> JoinOverrideGenerator::visit_method(
          boost::starts_with(class_name, "Lcom/google") ||
          boost::starts_with(class_name, "Lkotlin/") ||
          boost::starts_with(class_name, "Ljava")) &&
-         overrides.size() >= options_.heuristics().k_android_join_override_threshold()) {
+         overrides.size() >= options_.heuristics().android_join_override_threshold()) {
       models.push_back(
           Model(method, context_, Model::Mode::NoJoinVirtualOverrides));
     }

--- a/source/model-generator/JoinOverrideGenerator.cpp
+++ b/source/model-generator/JoinOverrideGenerator.cpp
@@ -16,7 +16,7 @@ std::vector<Model> JoinOverrideGenerator::visit_method(
 
   // Do not join models at call sites for methods with too many overrides.
   const auto& overrides = context_.overrides->get(method);
-  if (overrides.size() >= Heuristics::kJoinOverrideThreshold) {
+  if (overrides.size() >= options_.heuristics().k_join_override_threshold()) {
     models.push_back(
         Model(method, context_, Model::Mode::NoJoinVirtualOverrides));
   } else {
@@ -25,7 +25,7 @@ std::vector<Model> JoinOverrideGenerator::visit_method(
          boost::starts_with(class_name, "Lcom/google") ||
          boost::starts_with(class_name, "Lkotlin/") ||
          boost::starts_with(class_name, "Ljava")) &&
-        overrides.size() >= Heuristics::kAndroidJoinOverrideThreshold) {
+         overrides.size() >= options_.heuristics().k_android_join_override_threshold()) {
       models.push_back(
           Model(method, context_, Model::Mode::NoJoinVirtualOverrides));
     }

--- a/source/model-generator/ModelGenerator.cpp
+++ b/source/model-generator/ModelGenerator.cpp
@@ -284,7 +284,8 @@ void generator::add_propagation_to_return(
       /* output_paths */ PathTreeDomain{{Path{}, collapse_depth}},
       /* inferred_features */ FeatureMayAlwaysSet::bottom(),
       /* locally_inferred_features */ FeatureMayAlwaysSet::bottom(),
-      /* user_features */ user_features));
+      /* user_features */ user_features),
+      context.options->heuristics());
 }
 
 void generator::add_propagation_to_parameter(
@@ -307,7 +308,8 @@ void generator::add_propagation_to_parameter(
       /* output_paths */ PathTreeDomain{{Path{}, collapse_depth}},
       /* inferred_features */ FeatureMayAlwaysSet::bottom(),
       /* locally_inferred_features */ FeatureMayAlwaysSet::bottom(),
-      /* user_features */ user_features));
+      /* user_features */ user_features),
+      context.options->heuristics());
 }
 
 void generator::add_propagation_to_self(

--- a/source/model-generator/ModelTemplates.cpp
+++ b/source/model-generator/ModelTemplates.cpp
@@ -169,13 +169,15 @@ void PropagationTemplate::instantiate(
         /* global_transforms */ nullptr);
   }
 
-  model.add_propagation(PropagationConfig(
-      input_port,
-      kind,
-      PathTreeDomain{{output_port.path(), collapse_depth_}},
-      inferred_features_,
-      /* locally_inferred_features */ FeatureMayAlwaysSet::bottom(),
-      user_features_));
+  model.add_propagation(
+    PropagationConfig(
+        input_port,
+        kind,
+        PathTreeDomain{{output_port.path(), collapse_depth_}},
+        inferred_features_,
+        /* locally_inferred_features */ FeatureMayAlwaysSet::bottom(),
+        user_features_),
+      context.options->heuristics());
 }
 
 PortSanitizerTemplate::PortSanitizerTemplate(
@@ -239,7 +241,8 @@ void SinkTemplate::instantiate(
     Model& model) const {
   model.add_sink(
       port_.instantiate(parameter_positions),
-      sink_.instantiate(method, context, parameter_positions));
+      sink_.instantiate(method, context, parameter_positions),
+      context.options->heuristics());
 }
 
 ParameterSourceTemplate::ParameterSourceTemplate(
@@ -265,7 +268,8 @@ void ParameterSourceTemplate::instantiate(
     Model& model) const {
   model.add_parameter_source(
       port_.instantiate(parameter_positions),
-      source_.instantiate(method, context, parameter_positions));
+      source_.instantiate(method, context, parameter_positions),
+      context.options->heuristics());
 }
 
 GenerationTemplate::GenerationTemplate(
@@ -291,7 +295,8 @@ void GenerationTemplate::instantiate(
     Model& model) const {
   model.add_generation(
       port_.instantiate(parameter_positions),
-      source_.instantiate(method, context, parameter_positions));
+      source_.instantiate(method, context, parameter_positions),
+      context.options->heuristics());
 }
 
 SourceTemplate::SourceTemplate(TaintConfig source, AccessPathTemplate port)
@@ -310,11 +315,18 @@ SourceTemplate SourceTemplate::from_json(
 
 void SourceTemplate::instantiate(
     const TemplateVariableMapping& parameter_positions,
-    Model& model) const {
+    Model& model,
+    const Heuristics& heuristics) const {
   if (port_.root().is_argument()) {
-    model.add_parameter_source(port_.instantiate(parameter_positions), source_);
+    model.add_parameter_source(
+      port_.instantiate(parameter_positions),
+      source_,
+      heuristics);
   } else {
-    model.add_generation(port_.instantiate(parameter_positions), source_);
+    model.add_generation(
+      port_.instantiate(parameter_positions),
+      source_,
+      heuristics);
   }
 }
 
@@ -631,7 +643,7 @@ bool ForAllParameters::instantiate(
         updated = true;
       }
       for (const auto& source_template : source_templates_) {
-        source_template.instantiate(variable_mapping, model);
+        source_template.instantiate(variable_mapping, model, context.options->heuristics());
         updated = true;
       }
       for (const auto& propagation_template : propagation_templates_) {
@@ -701,14 +713,15 @@ std::optional<Model> ModelTemplate::instantiate(
 
   for (const auto& [port, taint_config_template] : generations_) {
     model.add_generation(
-        port, taint_config_template.instantiate(method, context));
+      port,
+      taint_config_template.instantiate(method, context),
+      context.options->heuristics());
   }
   for (const auto& [port, taint_config_template] : parameter_sources_) {
-    model.add_parameter_source(
-        port, taint_config_template.instantiate(method, context));
+    model.add_parameter_source(port, taint_config_template.instantiate(method, context), context.options->heuristics());
   }
   for (const auto& [port, taint_config_template] : sinks_) {
-    model.add_sink(port, taint_config_template.instantiate(method, context));
+    model.add_sink(port, taint_config_template.instantiate(method, context), context.options->heuristics());
   }
 
   // An instantiated model can be nonempty even when it is instantiated from

--- a/source/model-generator/ModelTemplates.h
+++ b/source/model-generator/ModelTemplates.h
@@ -172,7 +172,8 @@ class SourceTemplate final {
   static SourceTemplate from_json(const Json::Value& value, Context& context);
   void instantiate(
       const TemplateVariableMapping& parameter_positions,
-      Model& model) const;
+      Model& model,
+      const Heuristics& heuristics) const;
 
  private:
   TaintConfig source_;

--- a/source/model-generator/ServiceSourceGenerator.cpp
+++ b/source/model-generator/ServiceSourceGenerator.cpp
@@ -43,7 +43,8 @@ Model source_first_argument(
       AccessPath(Root(Root::Kind::Argument, 1)),
       generator::source(
           context,
-          /* kind */ "ServiceUserInput"));
+          /* kind */ "ServiceUserInput"),
+      context.options->heuristics());
   return model;
 }
 

--- a/source/model-generator/TaintInTaintOutGenerator.cpp
+++ b/source/model-generator/TaintInTaintOutGenerator.cpp
@@ -30,7 +30,7 @@ std::vector<Model> TaintInTaintOutGenerator::visit_method(
   if (method->is_abstract() || method->is_interface()) {
     const auto& overrides = context_.overrides->get(method);
     if (!overrides.empty() &&
-        overrides.size() < Heuristics::kJoinOverrideThreshold &&
+        overrides.size() < options_.heuristics().k_join_override_threshold() &&
         !context_.overrides->has_obscure_override_for(method)) {
       return {};
     }

--- a/source/model-generator/TaintInTaintOutGenerator.cpp
+++ b/source/model-generator/TaintInTaintOutGenerator.cpp
@@ -30,7 +30,7 @@ std::vector<Model> TaintInTaintOutGenerator::visit_method(
   if (method->is_abstract() || method->is_interface()) {
     const auto& overrides = context_.overrides->get(method);
     if (!overrides.empty() &&
-        overrides.size() < options_.heuristics().k_join_override_threshold() &&
+        overrides.size() < options_.heuristics().join_override_threshold() &&
         !context_.overrides->has_obscure_override_for(method)) {
       return {};
     }

--- a/source/model-generator/TaintInTaintThisGenerator.cpp
+++ b/source/model-generator/TaintInTaintThisGenerator.cpp
@@ -45,7 +45,7 @@ std::vector<Model> TaintInTaintThisGenerator::visit_method(
   if (method->is_abstract() || method->is_interface()) {
     const auto& overrides = context_.overrides->get(method);
     if (!overrides.empty() &&
-        overrides.size() < Heuristics::kJoinOverrideThreshold &&
+        overrides.size() < options_.heuristics().k_join_override_threshold() &&
         !context_.overrides->has_obscure_override_for(method)) {
       return {};
     }

--- a/source/model-generator/TaintInTaintThisGenerator.cpp
+++ b/source/model-generator/TaintInTaintThisGenerator.cpp
@@ -45,7 +45,7 @@ std::vector<Model> TaintInTaintThisGenerator::visit_method(
   if (method->is_abstract() || method->is_interface()) {
     const auto& overrides = context_.overrides->get(method);
     if (!overrides.empty() &&
-        overrides.size() < options_.heuristics().k_join_override_threshold() &&
+        overrides.size() < options_.heuristics().join_override_threshold() &&
         !context_.overrides->has_obscure_override_for(method)) {
       return {};
     }

--- a/source/tests/ClassPropertiesTest.cpp
+++ b/source/tests/ClassPropertiesTest.cpp
@@ -167,10 +167,12 @@ TEST_F(ClassPropertiesTest, InvokeUtil) {
   std::unordered_set<const Kind*> kind_set = {
       context.kind_factory->get("ActivityUserInput")};
   EXPECT_EQ(
-      class_properties.issue_features(activity, kind_set),
+      class_properties.issue_features(
+          activity, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet({via_caller_exported}));
   EXPECT_EQ(
-      class_properties.issue_features(util, kind_set),
+      class_properties.issue_features(
+          util, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet(
           {via_dependency_graph, via_caller_exported, via_class}));
 }
@@ -228,17 +230,21 @@ TEST_F(ClassPropertiesTest, MultipleCallers) {
   std::unordered_set<const Kind*> kind_set = {
       context.kind_factory->get("ActivityUserInput")};
   EXPECT_EQ(
-      class_properties.issue_features(main_activity, kind_set),
+      class_properties.issue_features(
+          main_activity, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet({via_caller_exported}));
   EXPECT_EQ(
-      class_properties.issue_features(parent_activity, kind_set),
+      class_properties.issue_features(
+          parent_activity, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet({via_caller_unexported}));
   EXPECT_EQ(
-      class_properties.issue_features(util, kind_set),
+      class_properties.issue_features(
+          util, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet(
           {via_dependency_graph, via_caller_exported, via_class}));
   EXPECT_EQ(
-      class_properties.issue_features(other, kind_set),
+      class_properties.issue_features(
+          other, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet({}));
 }
 
@@ -296,18 +302,22 @@ TEST_F(ClassPropertiesTest, MultipleCallersMultipleHops) {
   std::unordered_set<const Kind*> kind_set = {
       context.kind_factory->get("ActivityUserInput")};
   EXPECT_EQ(
-      class_properties.issue_features(main_activity, kind_set),
+      class_properties.issue_features(
+          main_activity, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet({via_caller_exported}));
   EXPECT_EQ(
-      class_properties.issue_features(util, kind_set),
+      class_properties.issue_features(
+          util, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet(
           {via_dependency_graph, via_caller_exported, via_class}));
   EXPECT_EQ(
-      class_properties.issue_features(util_inner, kind_set),
+      class_properties.issue_features(
+          util_inner, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet(
           {via_dependency_graph, via_caller_exported, via_class}));
   EXPECT_EQ(
-      class_properties.issue_features(parent_activity, kind_set),
+      class_properties.issue_features(
+          parent_activity, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet({via_caller_unexported}));
 }
 
@@ -354,14 +364,17 @@ TEST_F(ClassPropertiesTest, UnexportedHop) {
   std::unordered_set<const Kind*> kind_set = {
       context.kind_factory->get("ActivityUserInput")};
   EXPECT_EQ(
-      class_properties.issue_features(main_activity, kind_set),
+      class_properties.issue_features(
+          main_activity, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet({via_caller_exported}));
   EXPECT_EQ(
-      class_properties.issue_features(parent_activity, kind_set),
+      class_properties.issue_features(
+          parent_activity, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet({via_caller_unexported}));
   // Stop traversal at unexported as it may introduce FPs.
   EXPECT_EQ(
-      class_properties.issue_features(util, kind_set),
+      class_properties.issue_features(
+          util, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet(
           {via_dependency_graph, via_caller_unexported, via_class}));
 }
@@ -423,18 +436,22 @@ TEST_F(ClassPropertiesTest, Cyclic) {
   std::unordered_set<const Kind*> kind_set = {
       context.kind_factory->get("ActivityUserInput")};
   EXPECT_EQ(
-      class_properties.issue_features(main_activity, kind_set),
+      class_properties.issue_features(
+          main_activity, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet({via_caller_exported}));
   EXPECT_EQ(
-      class_properties.issue_features(activity1, kind_set),
+      class_properties.issue_features(
+          activity1, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet(
           {via_dependency_graph, via_caller_exported, via_class}));
   EXPECT_EQ(
-      class_properties.issue_features(activity2, kind_set),
+      class_properties.issue_features(
+          activity2, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet(
           {via_dependency_graph, via_caller_exported, via_class}));
   EXPECT_EQ(
-      class_properties.issue_features(util, kind_set),
+      class_properties.issue_features(
+          util, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet(
           {via_dependency_graph, via_caller_exported, via_class}));
 }
@@ -470,10 +487,12 @@ TEST_F(ClassPropertiesTest, NestedClass) {
   std::unordered_set<const Kind*> kind_set = {
       context.kind_factory->get("ActivityUserInput")};
   EXPECT_EQ(
-      class_properties.issue_features(activity, kind_set),
+      class_properties.issue_features(
+          activity, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet({via_caller_exported}));
   EXPECT_EQ(
-      class_properties.issue_features(util, kind_set),
+      class_properties.issue_features(
+          util, kind_set, context.options->heuristics()),
       FeatureMayAlwaysSet(
           {via_dependency_graph, via_caller_exported, via_nested_class}));
 }

--- a/source/tests/JsonTest.cpp
+++ b/source/tests/JsonTest.cpp
@@ -2908,8 +2908,8 @@ TEST_F(JsonTest, CallEffectModel) {
   Model effect_source_model(entry_method, context);
   effect_source_model.add_call_effect_source(
       AccessPath(Root(Root::Kind::CallEffectCallChain)),
-      test::make_leaf_taint_config(
-          context.kind_factory->get("CallChainOrigin")));
+      test::make_leaf_taint_config(context.kind_factory->get("CallChainOrigin")),
+      context.options->heuristics());
 
   EXPECT_EQ(
       test::sorted_json(effect_source_model.to_json(ExportOriginsMode::Always)),
@@ -2938,7 +2938,8 @@ TEST_F(JsonTest, CallEffectModel) {
   Model effect_sink_model(exit_method, context);
   effect_sink_model.add_call_effect_sink(
       AccessPath(Root(Root::Kind::CallEffectCallChain)),
-      test::make_leaf_taint_config(context.kind_factory->get("CallChainSink")));
+      test::make_leaf_taint_config( context.kind_factory->get("CallChainSink")),
+      context.options->heuristics());
   EXPECT_EQ(
       test::sorted_json(effect_sink_model.to_json(ExportOriginsMode::Always)),
       test::parse_json(R"#({

--- a/source/tests/ModelTest.cpp
+++ b/source/tests/ModelTest.cpp
@@ -81,15 +81,23 @@ TEST_F(ModelTest, remove_kinds_call_effects) {
   // Add call effect sources
   auto call_effect_port = AccessPath(Root(Root::Kind::CallEffectCallChain));
   model_with_removable_kind.add_call_effect_source(
-      call_effect_port, test::make_leaf_taint_config(source_kind));
+      call_effect_port,
+      test::make_leaf_taint_config(source_kind),
+      context.options->heuristics());
   model_with_removable_kind.add_call_effect_source(
-      call_effect_port, test::make_leaf_taint_config(removable_source_kind));
+      call_effect_port,
+      test::make_leaf_taint_config(removable_source_kind),
+      context.options->heuristics());
 
   // Add call effect sinks
   model_with_removable_kind.add_call_effect_sink(
-      call_effect_port, test::make_leaf_taint_config(sink_kind));
+      call_effect_port,
+      test::make_leaf_taint_config(sink_kind),
+      context.options->heuristics());
   model_with_removable_kind.add_call_effect_sink(
-      call_effect_port, test::make_leaf_taint_config(removable_sink_kind));
+      call_effect_port,
+      test::make_leaf_taint_config(removable_sink_kind),
+      context.options->heuristics());
 
   model_with_removable_kind.remove_kinds(
       {removable_source_kind, removable_sink_kind});
@@ -98,10 +106,14 @@ TEST_F(ModelTest, remove_kinds_call_effects) {
       /* method */ nullptr, context);
   // Add expected call effect source
   model_without_removable_kind.add_call_effect_source(
-      call_effect_port, test::make_leaf_taint_config(source_kind));
+      call_effect_port,
+      test::make_leaf_taint_config(source_kind),
+      context.options->heuristics());
   // Add expected call effect sink
   model_without_removable_kind.add_call_effect_sink(
-      call_effect_port, test::make_leaf_taint_config(sink_kind));
+      call_effect_port,
+      test::make_leaf_taint_config(sink_kind),
+      context.options->heuristics());
 
   EXPECT_EQ(model_with_removable_kind, model_without_removable_kind);
 }
@@ -1159,7 +1171,8 @@ TEST_F(ModelTest, SourceKinds) {
   Model model_with_call_effect_source;
   model_with_call_effect_source.add_call_effect_source(
       AccessPath(Root(Root::Kind::CallEffectIntent)),
-      test::make_leaf_taint_config(source_kind1));
+      test::make_leaf_taint_config(source_kind1),
+      context.options->heuristics());
   EXPECT_THAT(
       model_with_call_effect_source.source_kinds(),
       testing::UnorderedElementsAre(source_kind1));
@@ -1208,7 +1221,8 @@ TEST_F(ModelTest, SinkKinds) {
   Model model_with_call_effect_sink;
   model_with_call_effect_sink.add_call_effect_sink(
       AccessPath(Root(Root::Kind::CallEffectIntent)),
-      test::make_leaf_taint_config(sink_kind1));
+      test::make_leaf_taint_config(sink_kind1),
+      context.options->heuristics());
   EXPECT_THAT(
       model_with_call_effect_sink.sink_kinds(),
       testing::UnorderedElementsAre(sink_kind1));

--- a/source/tests/RegistryTest.cpp
+++ b/source/tests/RegistryTest.cpp
@@ -122,7 +122,6 @@ TEST_F(RegistryTest, JoinWith) {
       /* field_models_value */ test::parse_json(R"([])"),
       /* literal_models_value */ test::parse_json(R"([])")));
 
-  auto model = Model();
 
   EXPECT_EQ(registry.get(method).generations().elements().size(), 1);
   EXPECT_EQ(

--- a/source/tests/Test.cpp
+++ b/source/tests/Test.cpp
@@ -29,10 +29,34 @@ Test::Test() : global_redex_context_(/* allow_class_duplicates */ false){};
 ContextGuard::ContextGuard()
     : global_redex_context_(/* allow_class_duplicates */ false){};
 
+/**
+ * Empty options. Useful to initialize an empty context.
+ */
+std::unique_ptr<Options> make_empty_options() {
+  return std::make_unique<Options>(
+      std::vector<std::string>(),
+      std::vector<std::string>(),
+      std::vector<std::string>(),
+      std::vector<std::string>(),
+      std::vector<std::string>(),
+      std::vector<std::string>(),
+      ".",
+      std::vector<std::string>(),
+      true,
+      true,
+      true,
+      std::vector<ModelGeneratorConfiguration>(),
+      std::vector<std::string>(),
+      true,
+      true
+    );
+}
+
 Context make_empty_context() {
   Context context;
   context.methods = std::make_unique<Methods>();
   context.positions = std::make_unique<Positions>();
+  context.options = make_empty_options();
   return context;
 }
 

--- a/source/tests/Test.cpp
+++ b/source/tests/Test.cpp
@@ -34,21 +34,21 @@ ContextGuard::ContextGuard()
  */
 std::unique_ptr<Options> make_empty_options() {
   return std::make_unique<Options>(
-      std::vector<std::string>(),
-      std::vector<std::string>(),
-      std::vector<std::string>(),
-      std::vector<std::string>(),
-      std::vector<std::string>(),
-      std::vector<std::string>(),
-      ".",
-      std::vector<std::string>(),
-      true,
-      true,
-      true,
-      std::vector<ModelGeneratorConfiguration>(),
-      std::vector<std::string>(),
-      true,
-      true
+      /* models_path */ std::vector<std::string>(),
+      /* field_models_paths */ std::vector<std::string>(),
+      /* literal_models_paths */ std::vector<std::string>(),
+      /* rules_paths */ std::vector<std::string>(),
+      /* lifecycles_paths */ std::vector<std::string>(),
+      /* shims_paths */ std::vector<std::string>(),
+      /* graphql_metadata_paths */ ".",
+      /* proguard_configuration_paths */ std::vector<std::string>(),
+      /* sequential */ true,
+      /* skip_source_indexing */ true,
+      /* skip_analysis */true,
+      /* model_generators_configuration */ std::vector<ModelGeneratorConfiguration>(),
+      /* model_generator_search_paths */ std::vector<std::string>(),
+      /* remove_unreachable_code */ true,
+      /* emit_all_via_cast_features */ true
     );
 }
 


### PR DESCRIPTION
This PR makes it possible to configure some of the heuristics parameters used during the analysis with a JSON file.
The file can be specified with the `--heuristics PATH_TO_CONFIG` parameter.
The argument is optional, and parameters that are not specified are set to a default value.
Most of the parameters can be set, with a few exceptions:
* `kSourceSinkTreeWideningHeight`, `kMaxNumberLocalPositions`, and `kPropagationOutputPathTreeWideningHeight` cannot be specified at runtime, as they are needed at compile time.
* `kPropagationMaxOutputPathSize`, `kPropagationMaxOutputPathLeaves` are used in `Frame`. Adding a pointer to the `Heuristics` instance would require many non-trivial modifications to the codebase.
* `kPropagationMaxCollapseDepth` is used in `BackwardTaintEnvironment` and `BackwardTaintTransfer`. Adding a pointer to the `Heuristics` instance would require many non-trivial modifications to the codebase.

I think it would still be possible to make `kPropagationMaxOutputPathSize`, `kPropagationMaxOutputPathLeaves`, and `kPropagationMaxCollapseDepth` configurable at runtime, but this might result in a less polished interface for the `Frame`, `BackwardTaintEnvironment`, and `BackwardTaintTransfer` classes.

The `Model` class required non-trivial modifications to have access to the `Heuristics` object.
Nevertheless, this changes did not impact the codebase too much.

The documentation has been updated.