### PR TITLE
Fix some errors

### DIFF
--- a/source/FrameType.cpp
+++ b/source/FrameType.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <mariana-trench/Assert.h>
 #include <mariana-trench/FrameType.h>
 #include <mariana-trench/JsonValidation.h>
 
@@ -33,6 +34,7 @@ std::string FrameType::to_trace_string() const {
     case FrameType::Kind::Sink:
       return "sink";
   }
+  mt_unreachable();
 }
 
 std::ostream& operator<<(std::ostream& out, const FrameType& frame_type) {

--- a/source/ModelValidator.cpp
+++ b/source/ModelValidator.cpp
@@ -101,8 +101,8 @@ std::unique_ptr<ModelValidator> make_validator(
     case ModelValidationType::EXPECT_NO_ISSUE:
       return std::make_unique<ExpectNoIssue>(
           ExpectNoIssue::from_annotation(annotation_elements));
-      break;
   }
+  mt_unreachable();
 }
 
 std::vector<std::unique_ptr<ModelValidator>> validators_from_annotation(

--- a/source/SourceSinkWithExploitabilityRule.cpp
+++ b/source/SourceSinkWithExploitabilityRule.cpp
@@ -63,6 +63,7 @@ std::optional<CoveredRule> SourceSinkWithExploitabilityRule::coverage(
       .code = code(),
       .used_sources = std::move(used_rule_sources),
       .used_sinks = std::move(used_rule_sinks),
+      .used_transforms = TransformSet{},
   };
 }
 

--- a/source/TransformOperations.cpp
+++ b/source/TransformOperations.cpp
@@ -39,13 +39,13 @@ TaintTree apply_propagation(
 
   mt_assert(
       propagation_call_info.call_kind().is_propagation_with_trace() ||
-      propagation_call_info.call_kind().is_propagation() &&
-          std::any_of(
-              all_transforms->begin(),
-              all_transforms->end(),
-              [](const Transform* transform) {
-                return transform->is<SanitizerSetTransform>();
-              }));
+      (propagation_call_info.call_kind().is_propagation() &&
+       std::any_of(
+           all_transforms->begin(),
+           all_transforms->end(),
+           [](const Transform* transform) {
+             return transform->is<SanitizerSetTransform>();
+           })));
 
   if (direction == TransformDirection::Forward) {
     all_transforms = context->transforms_factory.reverse(all_transforms);

--- a/source/Types.cpp
+++ b/source/Types.cpp
@@ -430,9 +430,8 @@ std::unique_ptr<TypeEnvironments> Types::infer_types_for_method(
           instruction, &current_state);
 
       LOG(log_method ? 0 : 5,
-          "GTA: Analyzed instruction `{}`. RegEnv: {}",
-          show(instruction),
-          show(current_state.get_reg_environment()));
+          "GTA: Analyzed instruction `{}`.",
+          show(instruction));
 
       if (!is_interesting_opcode(instruction->opcode())) {
         continue;


### PR DESCRIPTION
Summary:
- Handle switch statements without defaults with mt_unreachable() 
- `get_reg_environment()` returns a reference to `RegTypeEnvironment`, so we shouldn't use `show()` + it doesn't provide `operator<<`. It's an abstract domain and expands to a whole bunch of stuff trying to find it. Let's just remove from logging and see if the build works.

Reviewed By: arthaud

Differential Revision: D72402092


