### PR TITLE
Fix open source build error with fmt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           git checkout 9.1.0
           mkdir build
           cd build
-          cmake -DCMAKE_INSTALL_PREFIX="../install" ..
+          cmake -DCMAKE_CXX_STANDARD=17 -DFMT_TEST=OFF -DCMAKE_INSTALL_PREFIX="../install" ..
           make -j$(sysctl -n hw.ncpu)
           make install
           cd ../..
@@ -63,7 +63,7 @@ jobs:
           git checkout 9.1.0
           mkdir build
           cd build
-          cmake -DCMAKE_INSTALL_PREFIX="../install" ..
+          cmake -DCMAKE_CXX_STANDARD=17 -DFMT_TEST=OFF -DCMAKE_INSTALL_PREFIX="../install" ..
           make -j$(nproc)
           make install
           cd ../..

--- a/documentation/website/documentation/build_from_source.md
+++ b/documentation/website/documentation/build_from_source.md
@@ -86,7 +86,7 @@ $ cd "$MARIANA_TRENCH_DIRECTORY/dependencies"
 $ git clone -b 9.1.0 https://github.com/fmtlib/fmt.git
 $ mkdir fmt/build
 $ cd fmt/build
-$ cmake -DCMAKE_INSTALL_PREFIX="$MARIANA_TRENCH_DIRECTORY/install" ..
+$ cmake -DCMAKE_CXX_STANDARD=17 -DFMT_TEST=OFF -DCMAKE_INSTALL_PREFIX="$MARIANA_TRENCH_DIRECTORY/install" ..
 $ make -j4
 $ make install
 ```


### PR DESCRIPTION
Summary: Google test is used by fmt, and it now requires c++17. We can work around that by using `-DCMAKE_CXX_STANDARD=17`.

Differential Revision: D72448442


