### PR TITLE
Fix JsonValidation potential dangling references

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install dependencies
-        run: brew install cmake zlib boost googletest jsoncpp re2
+        run: brew install --formula cmake zlib boost googletest jsoncpp re2
 
       - name: Install Redex
         run: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install cmake zlib boost googletest jsoncpp re2 git
+          brew install --formula cmake zlib boost googletest jsoncpp re2 git
           sudo apt update
           sudo apt install default-jre default-jdk
 

--- a/source/JsonValidation.cpp
+++ b/source/JsonValidation.cpp
@@ -49,6 +49,16 @@ void JsonValidation::validate_object(
   }
 }
 
+void JsonValidation::validate_object(
+    const Json::Value& value,
+    const std::string& field,
+    const std::string& expected) {
+  if (value.isNull() || !value.isObject() || !value.isMember(field)) {
+    throw JsonValidationError(
+        value, /* field */ std::nullopt, /* expected */ expected);
+  }
+}
+
 void JsonValidation::validate_object(const Json::Value& value) {
   validate_object(value, /* expected */ "non-null object");
 }
@@ -56,7 +66,8 @@ void JsonValidation::validate_object(const Json::Value& value) {
 const Json::Value& JsonValidation::object(
     const Json::Value& value,
     const std::string& field) {
-  validate_object(value, fmt::format("non-null object with field `{}`", field));
+  validate_object(
+      value, field, fmt::format("non-null object with field `{}`", field));
   const auto& attribute = value[field];
   if (attribute.isNull() || !attribute.isObject()) {
     throw JsonValidationError(value, field, /* expected */ "non-null object");
@@ -127,7 +138,9 @@ int JsonValidation::integer(
     const Json::Value& value,
     const std::string& field) {
   validate_object(
-      value, fmt::format("non-null object with integer field `{}`", field));
+      value,
+      field,
+      fmt::format("non-null object with integer field `{}`", field));
   const auto& integer = value[field];
   if (integer.isNull() || !integer.isInt()) {
     throw JsonValidationError(value, field, /* expected */ "integer");
@@ -185,7 +198,9 @@ bool JsonValidation::boolean(
     const Json::Value& value,
     const std::string& field) {
   validate_object(
-      value, fmt::format("non-null object with boolean field `{}`", field));
+      value,
+      field,
+      fmt::format("non-null object with boolean field `{}`", field));
   const auto& boolean = value[field];
   if (boolean.isNull() || !boolean.isBool()) {
     throw JsonValidationError(value, field, /* expected */ "boolean");
@@ -223,10 +238,15 @@ const Json::Value& JsonValidation::null_or_array(
   validate_object(
       value,
       fmt::format("non-null object with null or array field `{}`", field));
+  if (!value.isMember(field)) {
+    return Json::Value::nullSingleton();
+  }
+
   const auto& null_or_array = value[field];
   if (!null_or_array.isNull() && !null_or_array.isArray()) {
     throw JsonValidationError(value, field, /* expected */ "null or array");
   }
+
   return null_or_array;
 }
 
@@ -243,6 +263,7 @@ const Json::Value& JsonValidation::nonempty_array(
     const std::string& field) {
   validate_object(
       value,
+      field,
       fmt::format("non-null object with non-empty array field `{}`", field));
   const auto& nonempty_array = value[field];
   if (nonempty_array.isNull() || !nonempty_array.isArray() ||
@@ -270,6 +291,7 @@ const Json::Value& JsonValidation::object_or_string(
     const std::string& field) {
   validate_object(
       value,
+      field,
       fmt::format("non-null object with object or string field `{}`", field));
   const auto& attribute = value[field];
   if (attribute.isNull() || (!attribute.isObject() && !attribute.isString())) {

--- a/source/JsonValidation.h
+++ b/source/JsonValidation.h
@@ -33,6 +33,10 @@ class JsonValidation final {
   static void validate_object(
       const Json::Value& value,
       const std::string& expected);
+  static void validate_object(
+      const Json::Value& value,
+      const std::string& field,
+      const std::string& expected);
 
   static const Json::Value& object(
       const Json::Value& value,


### PR DESCRIPTION
Summary:
Building with GCC shows a lot of warnings on JsonValidation methods as follows:
```
/home/runner/work/mariana-trench/mariana-trench/source/FieldModel.cpp:143:66: warning: possibly dangling reference to a temporary [-Wdangling-reference]
  143 |        JsonValidation::null_or_array(value, /* field */ "sources")) {
```

On close inspection, this might happen when we directly access a field as `json[field]` and return a reference to it iff `field` does not exist in the original `json` object. In this case, we return a reference to a temporary `Json::Value` object. Let's fix it. This diff adds:
- the methods that return a reference to a null/empty object returns a reference to `Json::Value::nullSingleton();` instead of the temporary.
- also adds `validate()` method with `field` as argument which does a `isMember()` check for it. Use this when we require the field to be present

Differential Revision: D72485842


