### PR TITLE
Fix compiler error due to missing FMT_DEPRECATED_OSTREAM define

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DREDEX_ROOT="$PWD/../redex/install" -Dfmt_ROOT="$PWD/../fmt/install" -DFMT_DEPRECATED_OSTREAM=ON -DEXCLUDE_INTEGRATION_TESTS="check_cast_types" -DCMAKE_INSTALL_PREFIX="../install" ..
+          cmake -DREDEX_ROOT="$PWD/../redex/install" -Dfmt_ROOT="$PWD/../fmt/install" -DEXCLUDE_INTEGRATION_TESTS="check_cast_types" -DCMAKE_INSTALL_PREFIX="../install" ..
           make -j$(sysctl -n hw.ncpu)
           make install
           make check -j$(sysctl -n hw.ncpu)
@@ -82,7 +82,7 @@ jobs:
           cd ../..
           mkdir build
           cd build
-          cmake -DREDEX_ROOT="$PWD/../redex/install" -Dfmt_ROOT="$PWD/../fmt/install" -DFMT_DEPRECATED_OSTREAM=ON -DEXCLUDE_INTEGRATION_TESTS="check_cast_types" -DCMAKE_INSTALL_PREFIX="../install" ..
+          cmake -DREDEX_ROOT="$PWD/../redex/install" -Dfmt_ROOT="$PWD/../fmt/install" -DEXCLUDE_INTEGRATION_TESTS="check_cast_types" -DCMAKE_INSTALL_PREFIX="../install" ..
           make -j$(nproc)
           make install
           make check -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,8 @@ else()
   message(WARNING "Compiler ${CMAKE_CXX_COMPILER_ID} is not currently supported.")
 endif()
 
-# If specified, enable automatic std::ostream insertion operator (operator<<) discovery for fmt >8
-if (FMT_DEPRECATED_OSTREAM)
+option(FMT_DEPRECATED_OSTREAM "Enable automatic std::ostream insertion operator (operator<<) discovery" OFF)
+if (FMT_DEPRECATED_OSTREAM OR ("${fmt_VERSION}" VERSION_GREATER "8"))
   add_compile_options("-DFMT_DEPRECATED_OSTREAM=ON")
 endif()
 


### PR DESCRIPTION
Summary:
We should automatically add `-DFMT_DEPRECATED_OSTREAM` when compiling with libfmt > 8.0.
We can automatically detect the version, so we don't really need the user to specify `-DFMT_DEPRECATED_OSTREAM=ON` themselves.

Differential Revision: D72554459


