### PR TITLE
Fix cmake error due to removed boost component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ endif ()
 find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Boost 1.75.0 REQUIRED
-             COMPONENTS system filesystem regex program_options iostreams thread
+             COMPONENTS filesystem regex program_options iostreams thread
              CONFIG)
 # CMake's provided `FindGTest.cmake` does not define GMock.
 # We use `CONFIG` to find the `GTestConfig.cmake` provided by gtest, which properly defines GMock.
@@ -118,7 +118,6 @@ add_library(mariana-trench-library STATIC ${library_sources})
 target_link_libraries(mariana-trench-library PUBLIC
                       Threads::Threads
                       ZLIB::ZLIB
-                      Boost::system
                       Boost::regex
                       Boost::program_options
                       Boost::iostreams


### PR DESCRIPTION
Summary:
Boost 1.89.0 removed boost.system has a component because it is header only:
https://github.com/boostorg/system/issues/132

Since it's header only since 1.69.0 and we only support boost >= 1.75.0, we should be fine with removing it from the component list.

Differential Revision: D81122718


