### PR TITLE
Fix --sequential flag serialization in the shim

### DIFF
--- a/shim/shim.py
+++ b/shim/shim.py
@@ -574,9 +574,10 @@ def _add_analysis_arguments(parser: argparse.ArgumentParser) -> None:
     analysis_arguments.add_argument(
         "--sequential",
         action="store",
+        type=_str_to_bool,
         nargs="?",
+        const=True,
         default=False,
-        choices=["true", "false"],
         help="Run the analysis sequentially, one a single thread.",
     )
     analysis_arguments.add_argument(


### PR DESCRIPTION
## Summary

The `--sequential` flag in the Python shim was the odd one out among the boolean CLI options: every other boolean flag uses `type=_str_to_bool`, `nargs='?'`, `const=True`, `default=False`, but `--sequential` used `nargs='?'` with `choices=["true", "false"]` and no converter or const.

This made the flag broken in both usage patterns:

- `mariana-trench --sequential` -> the option is `None` -> the shim writes `"sequential": null` into the config JSON -> `JsonValidation::optional_boolean` treats null as "use default" (false), so the analysis silently runs in parallel even though the user asked for sequential.
- `mariana-trench --sequential true` or `--sequential=false` -> the option is the *string* `"true"`/`"false"` -> the shim writes `"sequential": "true"` into the config -> `JsonValidation::optional_boolean` requires a JSON boolean and throws `JsonValidationError`, aborting the whole analysis.

The `sequential` option is consumed by `Interprocedural.cpp`, where it forces the analysis onto a single thread, so the bug is user-visible.

This change aligns `--sequential` with all the other boolean flags so it always serializes to a real JSON boolean.